### PR TITLE
Add Hawkeye Innovations mock server demo

### DIFF
--- a/client-demos/hawkeye-client.js
+++ b/client-demos/hawkeye-client.js
@@ -1,0 +1,21 @@
+const { startServer } = require('../mcp-servers/hawkeye-innovations/server');
+
+async function runDemo() {
+  const server = startServer(3000);
+  // wait briefly for server to start
+  await new Promise(r => setTimeout(r, 100));
+
+  const healthRes = await fetch('http://localhost:3000/health');
+  const healthJson = await healthRes.json();
+  console.log('GET /health =>', healthJson);
+
+  const mockRes = await fetch('http://localhost:3000/mock-data');
+  const mockJson = await mockRes.json();
+  console.log('GET /mock-data =>', mockJson);
+
+  server.close();
+}
+
+runDemo().catch(err => {
+  console.error('Demo failed', err);
+});

--- a/mcp-servers/hawkeye-innovations/server.js
+++ b/mcp-servers/hawkeye-innovations/server.js
@@ -1,0 +1,23 @@
+const http = require('http');
+
+function handler(req, res) {
+  res.setHeader('Content-Type', 'application/json');
+  if (req.url === '/health') {
+    res.end(JSON.stringify({ status: 'ok', data: 'hawkeye-innovations server ready' }));
+  } else if (req.url === '/mock-data') {
+    res.end(JSON.stringify({ status: 'ok', data: { message: 'This is a mock response' } }));
+  } else {
+    res.statusCode = 404;
+    res.end(JSON.stringify({ status: 'error', data: 'Not Found' }));
+  }
+}
+
+function startServer(port = 3000) {
+  const server = http.createServer(handler);
+  server.listen(port, () => {
+    console.log(`Hawkeye Innovations server listening on port ${port}`);
+  });
+  return server;
+}
+
+module.exports = { startServer };


### PR DESCRIPTION
## Summary
- add simple Hawkeye Innovations HTTP server with health and mock-data endpoints returning `{ status, data }`
- include demo client script that starts the server and logs JSON responses

## Testing
- `npm test` (fails: Missing script: "test")
- `node client-demos/hawkeye-client.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7394e45588330a4247d8c0993f905