### PR TITLE
chore: configure Netlify Hawk-Eye function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,7 +263,8 @@ analytics-cache/
 # Deployment and CI/CD
 # =============================================================================
 .vercel/
-.netlify/
+.netlify/*
+!.netlify/config
 .firebase/
 
 # Terraform
@@ -455,5 +456,4 @@ secrets.env
 
 # Platform-specific
 .vercel/
-.netlify/
 wrangler.toml.local

--- a/.netlify/config
+++ b/.netlify/config
@@ -1,0 +1,10 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+  functions = "netlify/functions"
+
+[[redirects]]
+  from = "/hawkeye/*"
+  to = "/.netlify/functions/hawkeye/:splat"
+  status = 200
+


### PR DESCRIPTION
## Summary
- add Netlify config for Hawk-Eye function build and redirect
- track `.netlify/config` in git by updating `.gitignore`

## Testing
- `npm test` *(fails: Missing script "test")*
- `curl -I https://blaze-intelligence.netlify.app` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c71d1fe6e48330b10458f7e3e9367c