### PR TITLE
Use timezone-aware UTC timestamps across ingestion tooling

### DIFF
--- a/03_AUTOMATION/python/blaze_aggregator.py
+++ b/03_AUTOMATION/python/blaze_aggregator.py
@@ -7,9 +7,14 @@ Unifies team data from multiple leagues into a standardized JSON format.
 import json
 import csv
 import hashlib
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Any, Optional
+
+def current_utc_iso() -> str:
+    """Return the current UTC timestamp in ISO 8601 format with Z suffix."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
 
 def generate_team_id(league: str, team_name: str) -> str:
     """Generate a consistent team_id from league and team name."""
@@ -69,7 +74,7 @@ def process_mlb_teams(file_path: str) -> List[Dict[str, Any]]:
             "division": None,  # Could be added later (AL/NL, divisions)
             "market": market,
             "aliases": create_aliases(team_name, market),
-            "last_updated_iso": datetime.utcnow().isoformat() + "Z"
+            "last_updated_iso": current_utc_iso()
         }
         processed.append(processed_team)
     
@@ -94,7 +99,7 @@ def process_nfl_teams(file_path: str) -> List[Dict[str, Any]]:
             "division": None,  # Could be added later (AFC/NFC, divisions)
             "market": market,
             "aliases": create_aliases(team_name, market),
-            "last_updated_iso": datetime.utcnow().isoformat() + "Z"
+            "last_updated_iso": current_utc_iso()
         }
         processed.append(processed_team)
     
@@ -119,7 +124,7 @@ def process_fcs_teams(file_path: str) -> List[Dict[str, Any]]:
             "division": None,
             "market": market,
             "aliases": create_aliases(team_name, market),
-            "last_updated_iso": datetime.utcnow().isoformat() + "Z"
+            "last_updated_iso": current_utc_iso()
         }
         processed.append(processed_team)
     
@@ -144,7 +149,7 @@ def process_fbs_teams(file_path: str) -> List[Dict[str, Any]]:
             "division": None,
             "market": market,
             "aliases": create_aliases(team_name, market),
-            "last_updated_iso": datetime.utcnow().isoformat() + "Z"
+            "last_updated_iso": current_utc_iso()
         }
         processed.append(processed_team)
     

--- a/austin-portfolio-deploy/.github/workflows/ci-cd.yml
+++ b/austin-portfolio-deploy/.github/workflows/ci-cd.yml
@@ -493,7 +493,7 @@ jobs:
           
           # Update timestamp
           data = {
-            'last_updated': datetime.datetime.utcnow().isoformat(),
+            'last_updated': datetime.datetime.now(datetime.timezone.utc).isoformat(),
             'status': 'updated'
           }
           

--- a/ingestion/hs_agent.py
+++ b/ingestion/hs_agent.py
@@ -7,7 +7,7 @@ import json
 import os
 import sys
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Dict, Any
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -34,7 +34,7 @@ class HSAgent:
     def normalize(self, raw: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Normalize to Blaze schema"""
         players = []
-        now_iso = datetime.utcnow().isoformat() + 'Z'
+        now_iso = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
         
         for raw_player in raw.get('players', []):
             player = {
@@ -83,7 +83,7 @@ class HSAgent:
             with open(self.output_path, 'w') as f:
                 json.dump({
                     'league': 'HS-FB',
-                    'generated_at': datetime.utcnow().isoformat() + 'Z',
+                    'generated_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
                     'players': players
                 }, f, indent=2)
             

--- a/ingestion/intl_agent.py
+++ b/ingestion/intl_agent.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Dict, Any
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -35,7 +35,7 @@ class InternationalAgent:
     def normalize(self, raw: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Normalize to Blaze schema"""
         players = []
-        now_iso = datetime.utcnow().isoformat() + 'Z'
+        now_iso = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
         
         for raw_player in raw.get('players', []):
             player = {
@@ -84,7 +84,7 @@ class InternationalAgent:
             with open(self.output_path, 'w') as f:
                 json.dump({
                     'league': 'International',
-                    'generated_at': datetime.utcnow().isoformat() + 'Z',
+                    'generated_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
                     'players': players
                 }, f, indent=2)
             

--- a/ingestion/mlb_agent.py
+++ b/ingestion/mlb_agent.py
@@ -7,7 +7,7 @@ import json
 import os
 import sys
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Dict, Any
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -86,7 +86,7 @@ class MLBAgent:
     def normalize(self, raw: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Normalize to Blaze schema"""
         players = []
-        now_iso = datetime.utcnow().isoformat() + 'Z'
+        now_iso = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
         
         for raw_player in raw.get('players', []):
             player = {
@@ -135,7 +135,7 @@ class MLBAgent:
             with open(self.output_path, 'w') as f:
                 json.dump({
                     'league': 'MLB',
-                    'generated_at': datetime.utcnow().isoformat() + 'Z',
+                    'generated_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
                     'players': players
                 }, f, indent=2)
             

--- a/ingestion/ncaa_agent.py
+++ b/ingestion/ncaa_agent.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Dict, Any
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -36,7 +36,7 @@ class NCAAAgent:
     def normalize(self, raw: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Normalize to Blaze schema"""
         players = []
-        now_iso = datetime.utcnow().isoformat() + 'Z'
+        now_iso = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
         
         for raw_player in raw.get('players', []):
             player = {
@@ -85,7 +85,7 @@ class NCAAAgent:
             with open(self.output_path, 'w') as f:
                 json.dump({
                     'league': 'NCAA',
-                    'generated_at': datetime.utcnow().isoformat() + 'Z',
+                    'generated_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
                     'players': players
                 }, f, indent=2)
             

--- a/ingestion/nfl_agent.py
+++ b/ingestion/nfl_agent.py
@@ -7,7 +7,7 @@ import json
 import os
 import sys
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Dict, Any
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -45,7 +45,7 @@ class NFLAgent:
     def normalize(self, raw: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Normalize to Blaze schema"""
         players = []
-        now_iso = datetime.utcnow().isoformat() + 'Z'
+        now_iso = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
         
         for raw_player in raw.get('players', []):
             player = {
@@ -89,7 +89,7 @@ class NFLAgent:
             with open(self.output_path, 'w') as f:
                 json.dump({
                     'league': 'NFL',
-                    'generated_at': datetime.utcnow().isoformat() + 'Z',
+                    'generated_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
                     'players': players
                 }, f, indent=2)
             

--- a/ingestion/nil_agent.py
+++ b/ingestion/nil_agent.py
@@ -7,7 +7,7 @@ import json
 import os
 import sys
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Dict, Any
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -34,7 +34,7 @@ class NILAgent:
     def normalize(self, raw: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Normalize to Blaze schema"""
         players = []
-        now_iso = datetime.utcnow().isoformat() + 'Z'
+        now_iso = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
         
         for raw_player in raw.get('players', []):
             player = {
@@ -83,7 +83,7 @@ class NILAgent:
             with open(self.output_path, 'w') as f:
                 json.dump({
                     'league': 'NIL',
-                    'generated_at': datetime.utcnow().isoformat() + 'Z',
+                    'generated_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
                     'players': players
                 }, f, indent=2)
             

--- a/ingestion/readiness.py
+++ b/ingestion/readiness.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Any, Optional
 from statistics import mean
 
@@ -67,7 +67,7 @@ def categorize_player_status(readiness_score: Optional[float]) -> str:
 
 def generate_readiness_report(all_data: Dict[str, Any], focus_teams: List[str] = None) -> Dict[str, Any]:
     """Generate comprehensive readiness report"""
-    now_iso = datetime.utcnow().isoformat() + 'Z'
+    now_iso = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
     
     teams_data = []
     players_data = []

--- a/scripts/run_live_ingestion.py
+++ b/scripts/run_live_ingestion.py
@@ -8,7 +8,7 @@ import os
 import sys
 import subprocess
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Dict
 
 # Add parent directory to path
@@ -77,7 +77,7 @@ def check_api_keys() -> Dict[str, bool]:
 def run_full_pipeline(leagues: List[str] = None) -> bool:
     """Run the complete live data ingestion pipeline"""
     print("🚀 Starting Blaze Intelligence Live Data Ingestion")
-    print(f"Timestamp: {datetime.utcnow().isoformat()}Z")
+    print(f"Timestamp: {datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')}")
     print("-" * 60)
     
     # Check API keys

--- a/scripts/update_readiness.py
+++ b/scripts/update_readiness.py
@@ -7,7 +7,7 @@ Runs after data ingestion to update team readiness metrics
 import os
 import sys
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Add parent directory to path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -16,7 +16,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 def run_readiness_update():
     """Run the readiness board update"""
     print("🏆 Updating Blaze Intelligence Readiness Board")
-    print(f"Timestamp: {datetime.utcnow().isoformat()}Z")
+    print(f"Timestamp: {datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')}")
     print("-" * 60)
     
     try:
@@ -99,7 +99,7 @@ def generate_teams_summary():
         
         # Generate teams.json
         teams_data = {
-            'generated_at': datetime.utcnow().isoformat() + 'Z',
+            'generated_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
             'teams': teams,
             'analytics': {
                 'totalTeams': len(teams),


### PR DESCRIPTION
## Summary
- ensure HAV-F calculations and ingestion agents generate timezone-aware UTC timestamps for metadata
- centralize UTC ISO formatting in the aggregator and refresh CLI scripts to log Z-suffixed times
- update automated deployment workflow to record last-updated values with timezone context

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caf72a18308330b2003c4ecbef7f1b