### PR TITLE
Add unified build and serve scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "contact-form.js",
   "scripts": {
     "deploy:contact": "wrangler deploy contact-form.js --config ../wrangler-contact-api.toml --env production",
-    "deploy:auth": "wrangler deploy auth.js --config ../wrangler-auth-api.toml --env production"
+    "deploy:auth": "wrangler deploy auth.js --config ../wrangler-auth-api.toml --env production",
+    "build:unified": "npm --prefix blaze-intelligence-os-v2 install && bash -lc 'cd blaze-intelligence-os-v2 && npx vite build'",
+    "serve:unified": "npm --prefix blaze-intelligence-os-v2 install && BROWSER=none bash -lc 'cd blaze-intelligence-os-v2 && npx vite build && npx vite preview --host 0.0.0.0 --port 8000'"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3"


### PR DESCRIPTION
## Summary
- add a `build:unified` script that installs unified OS dependencies and runs its Vite production build
- add a `serve:unified` script that installs dependencies, builds, and previews the unified site on port 8000 without attempting to auto-open a browser

## Testing
- `npm run build:unified`
- `npm run serve:unified` (manually terminated after verifying the preview server started)


------
https://chatgpt.com/codex/tasks/task_e_68cb25d68e5c83308fcd4f1a7b94836c