### PR TITLE
Integrate domain matrix and harden realtime context

### DIFF
--- a/blaze-intelligence-os-v2/src/components/dashboard/Dashboard.tsx
+++ b/blaze-intelligence-os-v2/src/components/dashboard/Dashboard.tsx
@@ -8,6 +8,7 @@ import { PredictionsPanel } from './PredictionsPanel';
 import { DataIngestion } from './DataIngestion';
 import { NILCalculator } from './NILCalculator';
 import { PerformanceChart } from './PerformanceChart';
+import { DomainIntegrator } from './DomainIntegrator';
 
 export default function Dashboard() {
   const { selectedLeague, selectedTeam } = useBlazeContext();
@@ -19,7 +20,8 @@ export default function Dashboard() {
     { id: 'predictions', label: 'Predictions', icon: '🎯' },
     { id: 'vision', label: 'Vision AI', icon: '👁️' },
     { id: 'nil', label: 'NIL Calculator', icon: '💰' },
-    { id: 'data', label: 'Data Sources', icon: '📡' }
+    { id: 'data', label: 'Data Sources', icon: '📡' },
+    { id: 'domains', label: 'Domains', icon: '🌐' }
   ];
 
   return (
@@ -66,6 +68,7 @@ export default function Dashboard() {
         {activeTab === 'vision' && <VisionAIPanel />}
         {activeTab === 'nil' && <NILCalculator />}
         {activeTab === 'data' && <DataIngestion />}
+        {activeTab === 'domains' && <DomainIntegrator />}
       </div>
 
       {/* Footer Stats Bar */}

--- a/blaze-intelligence-os-v2/src/components/dashboard/DomainIntegrator.tsx
+++ b/blaze-intelligence-os-v2/src/components/dashboard/DomainIntegrator.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react';
+import { ExternalLink, AlertCircle, CheckCircle2, Activity, RefreshCw } from 'lucide-react';
+import { DOMAIN_INTEGRATIONS, DomainIntegration, DomainStatus } from '../../data/domainIntegrations';
+
+const STATUS_CONFIG: Record<DomainStatus, { label: string; badgeClass: string; icon: React.ComponentType<{ className?: string }> }> = {
+  online: {
+    label: 'Operational',
+    badgeClass: 'bg-green-500/10 text-green-500 border border-green-500/30',
+    icon: CheckCircle2
+  },
+  degraded: {
+    label: 'Degraded',
+    badgeClass: 'bg-yellow-500/10 text-yellow-500 border border-yellow-500/30',
+    icon: Activity
+  },
+  offline: {
+    label: 'Offline',
+    badgeClass: 'bg-red-500/10 text-red-500 border border-red-500/30',
+    icon: AlertCircle
+  },
+  pending: {
+    label: 'Pending',
+    badgeClass: 'bg-blue-500/10 text-blue-400 border border-blue-500/30',
+    icon: RefreshCw
+  }
+};
+
+const statusChip = (status: DomainStatus) => STATUS_CONFIG[status];
+
+export function DomainIntegrator() {
+  return (
+    <div className="space-y-6">
+      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-lg p-6">
+        <h2 className="text-xl font-display font-bold">Cross-Domain Integration Map</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+          Status overview of every satellite domain, automation environment, and content hub that feeds the Blaze Intelligence command center.
+        </p>
+      </div>
+
+      {DOMAIN_INTEGRATIONS.map((integration) => (
+        <DomainCard key={integration.domain} integration={integration} />
+      ))}
+    </div>
+  );
+}
+
+function DomainCard({ integration }: { integration: DomainIntegration }) {
+  const status = statusChip(integration.status);
+  const StatusIcon = status.icon;
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-lg shadow-lg border border-gray-200/60 dark:border-gray-800/60 p-6">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <span className={`inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-semibold ${status.badgeClass}`}>
+              <StatusIcon className="w-4 h-4" />
+              {status.label}
+            </span>
+            <a
+              href={integration.domain}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1 text-sm font-medium text-blaze-orange hover:text-blaze-orange-light"
+            >
+              {integration.domain.replace(/^https?:\/\//, '')}
+              <ExternalLink className="w-4 h-4" />
+            </a>
+          </div>
+
+          {integration.owner && (
+            <span className="text-xs uppercase tracking-wide text-gray-400">
+              Managed by {integration.owner}
+            </span>
+          )}
+        </div>
+
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{integration.label}</h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{integration.description}</p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {integration.capabilities.map(capability => (
+            <span
+              key={capability}
+              className="px-3 py-1 text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 rounded-full"
+            >
+              {capability}
+            </span>
+          ))}
+        </div>
+
+        {integration.notes && (
+          <div className="p-3 bg-blaze-orange/10 border border-blaze-orange/20 rounded-lg text-xs text-blaze-orange">
+            {integration.notes}
+          </div>
+        )}
+
+        {integration.actions && integration.actions.length > 0 && (
+          <div className="flex flex-wrap gap-3 pt-2">
+            {integration.actions.map(action => (
+              <a
+                key={`${integration.domain}-${action.label}`}
+                href={action.url}
+                target="_blank"
+                rel="noreferrer"
+                className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  action.type === 'primary'
+                    ? 'bg-blaze-orange text-white hover:bg-blaze-orange-light'
+                    : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-700'
+                }`}
+              >
+                {action.label}
+                <ExternalLink className="w-4 h-4" />
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/blaze-intelligence-os-v2/src/data/domainIntegrations.ts
+++ b/blaze-intelligence-os-v2/src/data/domainIntegrations.ts
@@ -1,0 +1,149 @@
+export type DomainStatus = 'online' | 'degraded' | 'offline' | 'pending';
+
+export interface DomainAction {
+  label: string;
+  url: string;
+  type?: 'primary' | 'secondary';
+}
+
+export interface DomainIntegration {
+  domain: string;
+  label: string;
+  status: DomainStatus;
+  description: string;
+  capabilities: string[];
+  owner?: string;
+  actions?: DomainAction[];
+  notes?: string;
+}
+
+export const DOMAIN_INTEGRATIONS: DomainIntegration[] = [
+  {
+    domain: 'https://blaze-intelligence.netlify.app',
+    label: 'Netlify Command Center',
+    status: 'online',
+    description: 'Production-grade React dashboard delivering the unified Blaze Intelligence experience.',
+    capabilities: [
+      'Real-time championship analytics views',
+      'Interactive NIL & prediction tooling',
+      'Integrated theming and status telemetry'
+    ],
+    owner: 'Netlify',
+    actions: [
+      { label: 'Open Production', url: 'https://blaze-intelligence.netlify.app', type: 'primary' }
+    ],
+    notes: 'Primary domain – all other environments are federated into this experience.'
+  },
+  {
+    domain: 'https://blaze-intelligence.replit.app',
+    label: 'Replit Prototype Hub',
+    status: 'offline',
+    description: 'Legacy sandbox used for rapid proof-of-concept demos and API experiments.',
+    capabilities: [
+      'Lightweight Node demos',
+      'Experimental API endpoints',
+      'Live coding collaboration'
+    ],
+    owner: 'Replit',
+    actions: [
+      { label: 'Review Prototype', url: 'https://blaze-intelligence.replit.app' }
+    ],
+    notes: 'Content migrated into the Netlify build; keep for future instant prototyping.'
+  },
+  {
+    domain: 'https://70d41e32.blaze-intelligence-platform.pages.dev',
+    label: 'Cloudflare Pages Automation',
+    status: 'offline',
+    description: 'Cloudflare Pages deployment housing automation workers and API mocks for integrations.',
+    capabilities: [
+      'Edge worker stubs',
+      'Platform automation hooks',
+      'Failover content routing'
+    ],
+    owner: 'Cloudflare',
+    actions: [
+      { label: 'Audit Deployment', url: 'https://70d41e32.blaze-intelligence-platform.pages.dev' }
+    ],
+    notes: 'Failed health checks replicated here so the Netlify UI can surface remediation guidance.'
+  },
+  {
+    domain: 'https://airtable.com',
+    label: 'Airtable Intelligence Base',
+    status: 'degraded',
+    description: 'Centralized Airtable workspace powering CRM, roster management, and automation data.',
+    capabilities: [
+      'Recruiting pipeline tracking',
+      'Automated content scheduling',
+      'Executive reporting views'
+    ],
+    owner: 'Airtable',
+    actions: [
+      { label: 'Sync Airtable Data', url: 'https://airtable.com' }
+    ],
+    notes: 'API credentials validated; re-authenticate to resume scheduled sync jobs.'
+  },
+  {
+    domain: 'https://blaze-3d.netlify.app',
+    label: '3D Immersive Experience',
+    status: 'pending',
+    description: 'High fidelity WebGL environment showcasing AR/VR-ready Blaze visualizations.',
+    capabilities: [
+      'Three.js championship arena',
+      'Interactive biometric overlays',
+      'Future AR headset support'
+    ],
+    owner: 'Netlify',
+    actions: [
+      { label: 'Launch 3D Experience', url: 'https://blaze-3d.netlify.app' }
+    ],
+    notes: 'Integrating hero assets into the React dashboard for a unified visual story.'
+  },
+  {
+    domain: 'https://new.express.adobe.com',
+    label: 'Adobe Express Brand Kit',
+    status: 'offline',
+    description: 'Brand storytelling templates and pitch collateral managed in Adobe Express.',
+    capabilities: [
+      'Executive-ready presentation templates',
+      'Motion graphics presets',
+      'Instant social cutdowns'
+    ],
+    owner: 'Adobe',
+    actions: [
+      { label: 'Open Brand Kit', url: 'https://new.express.adobe.com' }
+    ],
+    notes: 'Assets referenced inside the Netlify UI so creative stays in lockstep with analytics.'
+  },
+  {
+    domain: 'https://j8r5k8b9j.wixsite.com',
+    label: 'Legacy Wix Microsite',
+    status: 'offline',
+    description: 'Historical marketing microsite kept for archival content and testimonials.',
+    capabilities: [
+      'Archived case studies',
+      'Legacy lead capture forms',
+      'Transition content for alumni clients'
+    ],
+    owner: 'Wix',
+    actions: [
+      { label: 'Review Archive', url: 'https://j8r5k8b9j.wixsite.com' }
+    ],
+    notes: 'Key copy points already ported into the unified platform — keep as a content vault.'
+  },
+  {
+    domain: 'https://a4dc795e.blaze-intelligence.pages.dev',
+    label: 'Cloudflare Pages Fallback',
+    status: 'offline',
+    description: 'Failsafe static deployment mirroring the production dashboard for redundancy testing.',
+    capabilities: [
+      'Static export of dashboard UI',
+      'Disaster recovery drill target',
+      'Automated uptime probes'
+    ],
+    owner: 'Cloudflare',
+    actions: [
+      { label: 'Check Fallback', url: 'https://a4dc795e.blaze-intelligence.pages.dev' }
+    ],
+    notes: 'Health signals ingested by the Netlify build to highlight failed edge deployments.'
+  }
+];

--- a/blaze-intelligence-os-v2/src/data/fallbackSportsData.ts
+++ b/blaze-intelligence-os-v2/src/data/fallbackSportsData.ts
@@ -1,0 +1,144 @@
+import { AnalyticsMetrics, SportsData, SystemStatus } from '../types';
+
+const timestamp = () => new Date().toISOString();
+
+export const FALLBACK_SPORTS_DATA: SportsData = {
+  teams: [
+    {
+      id: 'mlb-stl',
+      name: 'St. Louis Cardinals',
+      league: 'MLB',
+      division: 'NL Central',
+      primaryColor: '#C41E3A',
+      secondaryColor: '#0A2253'
+    },
+    {
+      id: 'nfl-ten',
+      name: 'Tennessee Titans',
+      league: 'NFL',
+      division: 'AFC South',
+      primaryColor: '#4B92DB',
+      secondaryColor: '#0C2340'
+    },
+    {
+      id: 'nba-mem',
+      name: 'Memphis Grizzlies',
+      league: 'NBA',
+      division: 'Western Southwest',
+      primaryColor: '#5D76A9',
+      secondaryColor: '#12173F'
+    },
+    {
+      id: 'ncaa-tex',
+      name: 'Texas Longhorns',
+      league: 'NCAA',
+      division: 'Big 12',
+      primaryColor: '#BF5700',
+      secondaryColor: '#333F48'
+    }
+  ],
+  players: [
+    {
+      id: 'stl-goldschmidt',
+      name: 'Paul Goldschmidt',
+      number: 46,
+      position: '1B',
+      team: 'St. Louis Cardinals',
+      stats: {
+        games: 158,
+        average: 0.274,
+        ops: 0.845,
+        homeRuns: 28,
+        rbi: 92
+      }
+    },
+    {
+      id: 'ten-henry',
+      name: 'Derrick Henry',
+      number: 22,
+      position: 'RB',
+      team: 'Tennessee Titans',
+      stats: {
+        games: 17,
+        rushingYards: 1285,
+        touchdowns: 14,
+        yardsPerCarry: 4.5
+      }
+    },
+    {
+      id: 'mem-morant',
+      name: 'Ja Morant',
+      number: 12,
+      position: 'PG',
+      team: 'Memphis Grizzlies',
+      stats: {
+        games: 68,
+        points: 27.6,
+        assists: 8.3,
+        rebounds: 5.9
+      }
+    },
+    {
+      id: 'tex-ewers',
+      name: 'Quinn Ewers',
+      number: 3,
+      position: 'QB',
+      team: 'Texas Longhorns',
+      stats: {
+        games: 13,
+        completionPercentage: 66.2,
+        touchdowns: 28,
+        interceptions: 6
+      }
+    }
+  ],
+  games: [
+    {
+      id: 'mlb-stl-vs-chc',
+      homeTeam: 'St. Louis Cardinals',
+      awayTeam: 'Chicago Cubs',
+      date: '2025-03-28',
+      time: '19:15',
+      venue: 'Busch Stadium',
+      status: 'scheduled',
+      predictions: {
+        winner: 'St. Louis Cardinals',
+        confidence: 72,
+        projectedScore: { home: 5, away: 3 },
+        keyFactors: ['Pitching matchup', 'Home field advantage']
+      }
+    },
+    {
+      id: 'nfl-ten-vs-hou',
+      homeTeam: 'Tennessee Titans',
+      awayTeam: 'Houston Texans',
+      date: '2025-09-21',
+      time: '13:00',
+      venue: 'Nissan Stadium',
+      status: 'scheduled',
+      predictions: {
+        winner: 'Tennessee Titans',
+        confidence: 64,
+        projectedScore: { home: 24, away: 20 },
+        keyFactors: ['Division game', 'Run game efficiency']
+      }
+    }
+  ],
+  lastUpdated: timestamp()
+};
+
+export const FALLBACK_SYSTEM_STATUS: SystemStatus = {
+  api: 'operational',
+  database: 'operational',
+  analytics: 'operational',
+  visionAI: 'operational',
+  lastUpdated: timestamp()
+};
+
+export const FALLBACK_ANALYTICS: AnalyticsMetrics = {
+  accuracy: 94.6,
+  latency: 87,
+  dataPoints: 2800000,
+  activeUsers: 1247,
+  predictions: 3421
+};

--- a/blaze-intelligence-os-v2/src/vite-env.d.ts
+++ b/blaze-intelligence-os-v2/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+declare interface ImportMetaEnv {
+  readonly VITE_WS_URL?: string;
+}
+
+declare interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- add fallback data and safe websocket handling so the Blaze context works without a live socket
- capture the external domain capabilities in a dedicated dataset and expose them through a new dashboard tab
- type Vite environment access for the optional websocket endpoint

## Testing
- `npm run build` *(fails: repository already contains TypeScript errors in multiple untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc160abc008330a64d7f8e765f7845