### PR TITLE
Guard API config env access for browser execution

### DIFF
--- a/austin-portfolio-deploy/js/api-config.js
+++ b/austin-portfolio-deploy/js/api-config.js
@@ -3,15 +3,32 @@
  * Central configuration for all sports data APIs and services
  */
 
+const getEnvVar = (key, fallback) => {
+    if (typeof window !== 'undefined') {
+        const browserEnvSources = [window.BlazeEnv, window.__ENV__, window.__CONFIG__];
+        for (const source of browserEnvSources) {
+            if (source && typeof source === 'object' && source[key]) {
+                return source[key];
+            }
+        }
+    }
+
+    if (typeof process !== 'undefined' && process.env && process.env[key]) {
+        return process.env[key];
+    }
+
+    return fallback;
+};
+
 window.BlazeAPIConfig = {
     // SportsRadar API Configuration
     sportsRadar: {
         // Replace with your actual API keys
         keys: {
-            mlb: process.env?.SPORTRADAR_MLB_KEY || 'YOUR_MLB_API_KEY',
-            nfl: process.env?.SPORTRADAR_NFL_KEY || 'YOUR_NFL_API_KEY',
-            nba: process.env?.SPORTRADAR_NBA_KEY || 'YOUR_NBA_API_KEY',
-            ncaaf: process.env?.SPORTRADAR_NCAAF_KEY || 'YOUR_NCAAF_API_KEY'
+            mlb: getEnvVar('SPORTRADAR_MLB_KEY', 'YOUR_MLB_API_KEY'),
+            nfl: getEnvVar('SPORTRADAR_NFL_KEY', 'YOUR_NFL_API_KEY'),
+            nba: getEnvVar('SPORTRADAR_NBA_KEY', 'YOUR_NBA_API_KEY'),
+            ncaaf: getEnvVar('SPORTRADAR_NCAAF_KEY', 'YOUR_NCAAF_API_KEY')
         },
         endpoints: {
             mlb: {

--- a/austin-portfolio-deploy/js/sports-data-hub.js
+++ b/austin-portfolio-deploy/js/sports-data-hub.js
@@ -4,6 +4,29 @@
  * Integrates SportsRadar, Baseball Reference, Pro Football Focus, and more
  */
 
+const resolveEnvVar = (key, fallback) => {
+    if (typeof window !== 'undefined') {
+        const browserEnvSources = [
+            window.BlazeEnv,
+            window.__ENV__,
+            window.__CONFIG__,
+            window.BlazeAPIConfig && window.BlazeAPIConfig.envOverrides
+        ];
+
+        for (const source of browserEnvSources) {
+            if (source && typeof source === 'object' && source[key]) {
+                return source[key];
+            }
+        }
+    }
+
+    if (typeof process !== 'undefined' && process.env && process.env[key]) {
+        return process.env[key];
+    }
+
+    return fallback;
+};
+
 class SportsDataHub {
     constructor() {
         this.dataSources = {
@@ -98,10 +121,9 @@ class SportsDataHub {
     async loadApiKeys() {
         try {
             // Try to load from environment or localStorage
-            this.dataSources.sportsRadar.apiKey = 
-                localStorage.getItem('SPORTRADAR_API_KEY') || 
-                process.env?.SPORTRADAR_API_KEY || 
-                'demo_key'; // Fallback for demo
+            this.dataSources.sportsRadar.apiKey =
+                localStorage.getItem('SPORTRADAR_API_KEY') ||
+                resolveEnvVar('SPORTRADAR_API_KEY', 'demo_key'); // Fallback for demo
         } catch (error) {
             console.warn('API keys not configured, using demo mode');
         }


### PR DESCRIPTION
## Summary
- add a browser-safe helper in the API configuration to read injected values before falling back to process.env
- add a shared resolver in the sports data hub to safely source the SportsRadar key without direct process.env usage
- keep runtime initialization logic intact while avoiding crashes when process is undefined

## Testing
- npm run build
- node - <<'NODE' (smoke test for DOMContentLoaded initialization)


------
https://chatgpt.com/codex/tasks/task_e_68cc39b81f0c8330b8f7a1fb988447b1