### PR TITLE
Add Texas HS football aggregation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,38 @@ wrangler pages deploy
 ./03_AUTOMATION/shell/deploy-production.sh
 ```
 
+## 🏈 Texas High School Football API
+
+Blaze Intelligence now aggregates Texas high school football program data by stitching together MaxPreps game results, 247Sports recruiting intel, and Rivals rankings. The service normalizes records, schedules, player profiles, and consensus recruiting rankings into a single payload that can be consumed by dashboards, analytics notebooks, or downstream automations.
+
+**Endpoint**
+
+```http
+GET /api/texas-hs-football/program
+```
+
+**Query Parameters**
+
+- `team` *(optional)* – Friendly team name used for metadata when source pages do not expose it.
+- `season` *(optional)* – Target season, passed through to upstream scrapers when available.
+- `maxprepsTeamPath` *(recommended)* – Path or URL fragment to the MaxPreps program page (e.g. `tx/duncanville/duncanville-panthers/football`).
+- `maxprepsTeamId` *(alternative)* – MaxPreps numeric team identifier if the path is not known.
+- `s247TeamPath` *(optional)* – 247Sports team path or slug for recruiting coverage.
+- `rivalsTeamPath` *(optional)* – Rivals team path or slug for recruiting coverage.
+- `includeSchedule` *(default: true)* – Set to `false` to skip schedule scraping for faster responses.
+- `includePlayerStats` *(default: true)* – Set to `false` to bypass roster parsing.
+- `includeRecruiting` *(default: true)* – Set to `false` to suppress 247Sports and Rivals fetches.
+- `includeRaw` *(default: false)* – When `true`, returns the structured JSON blobs captured from each source.
+- `forceRefresh` *(default: false)* – Bypass the in-memory cache and fetch fresh data.
+
+**Example**
+
+```bash
+curl "http://localhost:5000/api/texas-hs-football/program?team=Duncanville+Panthers&season=2024&maxprepsTeamPath=tx/duncanville/duncanville-panthers/football&s247TeamPath=/college/texas/Season/2024-Football/Commits/&rivalsTeamPath=/teams/football/texas/commitments"
+```
+
+The API responds with a structured object that includes program metadata, records, advanced team stats, normalized schedule results, player summaries, combined recruiting boards, and quick-hit insights such as scoring margins or consensus rankings. All responses are cached for 15 minutes by default to protect upstream sources.
+
 ## 🤖 Developer Automation: Blaze Autopilot
 
 Accelerate cross-platform launches with the `automation/blaze-autopilot.ts` orchestrator. The script opportunistically fires any

--- a/server.js
+++ b/server.js
@@ -32,6 +32,8 @@ import BackupSystem from './src/backend/backup-system.js';
 import ballDontLieService from './src/services/ballDontLieService.js';
 import aiAnalyticsService from './src/services/aiAnalyticsService.js';
 
+import TexasHighSchoolFootballService from './services/highschool/texasHighSchoolFootballService.js';
+
 // Load environment variables
 dotenv.config();
 
@@ -49,6 +51,7 @@ app.set('trust proxy', 1);
 const sportsData = new SportsDataService();
 const liveSportsAdapter = new LiveSportsAdapter();
 const aiAnalytics = new AIAnalyticsService();
+const texasHsService = new TexasHighSchoolFootballService();
 const cardinalsAPI = new CardinalsDataIntegration();
 const digitalCombineBackend = new DigitalCombineBackend(pool);
 const instrumentation = new InstrumentationManager(process.env.NODE_ENV || 'development');
@@ -1453,6 +1456,52 @@ app.get('/api/cfb/rankings', async (req, res) => {
   } catch (error) {
     console.error('CFB rankings error:', error);
     res.status(500).json({ error: 'Failed to fetch CFB rankings', source: 'CollegeFootballData API' });
+  }
+});
+
+// Texas High School Football Unified API
+app.get('/api/texas-hs-football/program', async (req, res) => {
+  const {
+    team,
+    season,
+    maxprepsTeamPath,
+    maxprepsTeamId,
+    includeSchedule,
+    includePlayerStats,
+    includeRecruiting,
+    includeRaw,
+    forceRefresh
+  } = req.query;
+
+  const s247TeamPath = req.query.s247TeamPath || req.query.twentyFourSevenTeamPath;
+  const rivalsTeamPath = req.query.rivalsTeamPath || req.query.rivalsPath;
+
+  if (!maxprepsTeamPath && !maxprepsTeamId && !s247TeamPath && !rivalsTeamPath) {
+    return res.status(400).json({ error: 'At least one source identifier (MaxPreps, 247Sports, or Rivals) is required.' });
+  }
+
+  try {
+    const data = await texasHsService.getProgramData({
+      team,
+      season,
+      maxprepsTeamPath,
+      maxprepsTeamId,
+      twentyFourSevenTeamPath: s247TeamPath,
+      rivalsTeamPath,
+      includeSchedule: includeSchedule !== 'false',
+      includePlayerStats: includePlayerStats !== 'false',
+      includeRecruiting: includeRecruiting !== 'false',
+      includeRaw: includeRaw === 'true',
+      forceRefresh: forceRefresh === 'true'
+    });
+
+    res.json(data);
+  } catch (error) {
+    console.error('Texas HS football API error:', error);
+    res.status(500).json({
+      error: 'Failed to fetch Texas high school football data',
+      details: error.message
+    });
   }
 });
 

--- a/services/highschool/baseAdapter.js
+++ b/services/highschool/baseAdapter.js
@@ -1,0 +1,204 @@
+const DEFAULT_HEADERS = {
+  'User-Agent': 'BlazeIntelligenceTexasHS/1.0 (+https://blaze-intelligence.netlify.app)',
+  'Accept': 'text/html,application/json;q=0.9,*/*;q=0.8'
+};
+
+export default class BaseAdapter {
+  constructor({
+    name,
+    baseUrl = '',
+    defaultHeaders = {},
+    timeout = 12000,
+    minRequestInterval = 500
+  } = {}) {
+    this.name = name || 'unknown-adapter';
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+    this.timeout = timeout;
+    this.defaultHeaders = { ...DEFAULT_HEADERS, ...defaultHeaders };
+    this.minRequestInterval = minRequestInterval;
+    this.lastRequestTime = 0;
+  }
+
+  async fetch(url, {
+    headers = {},
+    method = 'GET',
+    searchParams,
+    timeout = this.timeout,
+    signal,
+    body
+  } = {}) {
+    const target = this.buildUrl(url, searchParams);
+    await this.respectRateLimit();
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
+
+    try {
+      const response = await fetch(target, {
+        method,
+        headers: { ...this.defaultHeaders, ...headers },
+        body,
+        signal: signal || controller.signal,
+        redirect: 'follow'
+      });
+
+      if (!response.ok) {
+        const snippet = await response.text().catch(() => '');
+        throw new Error(
+          `[${this.name}] Request failed (${response.status}) ${response.statusText} - ${snippet.slice(0, 200)}`
+        );
+      }
+
+      return response;
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        throw new Error(`[${this.name}] Request to ${target} timed out after ${timeout}ms`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async fetchJson(url, options) {
+    const response = await this.fetch(url, options);
+    return response.json();
+  }
+
+  async fetchHtml(url, options) {
+    const response = await this.fetch(url, options);
+    return response.text();
+  }
+
+  buildUrl(url, searchParams) {
+    let target = url;
+    if (!/^https?:\/\//i.test(url)) {
+      if (!this.baseUrl) {
+        throw new Error(`[${this.name}] Unable to resolve relative URL: ${url}`);
+      }
+      target = `${this.baseUrl}/${url.replace(/^\//, '')}`;
+    }
+
+    if (searchParams && Object.keys(searchParams).length) {
+      const parsed = new URL(target);
+      for (const [key, value] of Object.entries(searchParams)) {
+        if (value === undefined || value === null || value === '') continue;
+        parsed.searchParams.set(key, value);
+      }
+      target = parsed.toString();
+    }
+
+    return target;
+  }
+
+  async respectRateLimit() {
+    const now = Date.now();
+    const waitTime = this.minRequestInterval - (now - this.lastRequestTime);
+    if (waitTime > 0) {
+      await new Promise((resolve) => setTimeout(resolve, waitTime));
+    }
+    this.lastRequestTime = Date.now();
+  }
+
+  extractJsonLd(html) {
+    const matches = [...html.matchAll(/<script[^>]*type=['"]application\/ld\+json['"][^>]*>([\s\S]*?)<\/script>/gi)];
+    const documents = [];
+    for (const [, script] of matches) {
+      const content = script.trim();
+      if (!content) continue;
+      try {
+        const parsed = JSON.parse(content);
+        if (Array.isArray(parsed)) {
+          documents.push(...parsed);
+        } else {
+          documents.push(parsed);
+        }
+      } catch (error) {
+        // Ignore malformed JSON-LD blocks
+      }
+    }
+    return documents;
+  }
+
+  extractScriptJson(html, selectors = []) {
+    const targets = Array.isArray(selectors) ? selectors : [selectors];
+
+    for (const selector of targets) {
+      if (!selector) continue;
+
+      if (typeof selector === 'string') {
+        const idRegex = new RegExp(`<script[^>]*id=['"]${selector}['"][^>]*>([\s\S]*?)<\/script>`, 'i');
+        const idMatch = html.match(idRegex);
+        if (idMatch && idMatch[1]) {
+          const parsed = this.safeJsonParse(idMatch[1]);
+          if (parsed) return parsed;
+        }
+
+        const varRegex = new RegExp(`${selector}\s*=\s*({[\s\S]*?});`, 'i');
+        const varMatch = html.match(varRegex);
+        if (varMatch && varMatch[1]) {
+          const parsed = this.safeJsonParse(varMatch[1]);
+          if (parsed) return parsed;
+        }
+      } else if (selector.id) {
+        const idRegex = new RegExp(`<script[^>]*id=['"]${selector.id}['"][^>]*>([\s\S]*?)<\/script>`, selector.flags || 'i');
+        const idMatch = html.match(idRegex);
+        if (idMatch && idMatch[1]) {
+          const parsed = this.safeJsonParse(idMatch[1]);
+          if (parsed) return parsed;
+        }
+      } else if (selector.pattern) {
+        const pattern = new RegExp(selector.pattern, selector.flags || 'i');
+        const match = html.match(pattern);
+        if (match && match[1]) {
+          const parsed = this.safeJsonParse(match[1]);
+          if (parsed) return parsed;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  safeJsonParse(value) {
+    try {
+      if (typeof value !== 'string') {
+        return value;
+      }
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+
+      // Remove trailing semicolons or HTML comments
+      const sanitized = trimmed
+        .replace(/^[\s;]*/, '')
+        .replace(/[\s;]*$/, '')
+        .replace(/<\/?script>/gi, '')
+        .replace(/<!--([\s\S]*?)-->/g, '$1');
+
+      return JSON.parse(sanitized);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  parseNumber(value) {
+    if (value === undefined || value === null) return null;
+    if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+    const sanitized = String(value).replace(/[^0-9.\-]/g, '');
+    if (!sanitized) return null;
+    const parsed = parseFloat(sanitized);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  normalizeText(value) {
+    if (!value) return null;
+    return String(value).replace(/\s+/g, ' ').trim();
+  }
+
+  toDate(value) {
+    if (!value) return null;
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+    return date.toISOString();
+  }
+}

--- a/services/highschool/maxprepsAdapter.js
+++ b/services/highschool/maxprepsAdapter.js
@@ -1,0 +1,466 @@
+import BaseAdapter from './baseAdapter.js';
+
+function parseRecordString(adapter, value) {
+  if (!value) return null;
+  const normalized = String(value).replace(/[^0-9\-]/g, '').trim();
+  if (!normalized) return null;
+  const [wins, losses, ties] = normalized.split('-').map((part) => {
+    const parsed = parseInt(part, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  });
+  const totalGames = [wins, losses, ties].filter((n) => typeof n === 'number').reduce((acc, curr) => acc + curr, 0);
+  const winPct = typeof wins === 'number' && totalGames
+    ? Number((wins / totalGames).toFixed(3))
+    : null;
+  return {
+    value: normalized,
+    wins: typeof wins === 'number' ? wins : null,
+    losses: typeof losses === 'number' ? losses : null,
+    ties: typeof ties === 'number' ? ties : null,
+    games: totalGames || null,
+    winPercentage: winPct
+  };
+}
+
+export default class MaxPrepsAdapter extends BaseAdapter {
+  constructor(options = {}) {
+    super({
+      name: 'maxpreps',
+      baseUrl: 'https://www.maxpreps.com',
+      minRequestInterval: 750,
+      ...options
+    });
+  }
+
+  normalizeTeamPath(teamPath) {
+    if (!teamPath) return null;
+    return teamPath
+      .replace(/^https?:\/\/[^/]+\//i, '')
+      .replace(/^\//, '')
+      .replace(/\/$/, '');
+  }
+
+  buildSeasonPath(teamPath, season) {
+    const normalized = this.normalizeTeamPath(teamPath);
+    if (!normalized) return null;
+    if (!season) return normalized;
+    return `${normalized}/${season}`.replace(/\/+/g, '/');
+  }
+
+  async getTeamData({
+    teamPath,
+    teamId,
+    season,
+    includeSchedule = true,
+    includePlayerStats = true
+  }) {
+    const relativePath = teamId ? `m/team/${teamId}` : this.buildSeasonPath(teamPath, season);
+    if (!relativePath) {
+      throw new Error('[maxpreps] teamPath or teamId is required to fetch team data');
+    }
+
+    const requests = [
+      { key: 'summary', url: `${relativePath}/stats` }
+    ];
+
+    if (includeSchedule) {
+      requests.push({ key: 'schedule', url: `${relativePath}/schedule` });
+    }
+
+    if (includePlayerStats) {
+      requests.push({ key: 'roster', url: `${relativePath}/roster` });
+    }
+
+    const htmlResponses = {};
+    const fetchErrors = [];
+
+    await Promise.all(
+      requests.map(async ({ key, url }) => {
+        try {
+          htmlResponses[key] = await this.fetchHtml(url);
+        } catch (error) {
+          fetchErrors.push({ key, url, message: error.message });
+        }
+      })
+    );
+
+    const summaryHtml = htmlResponses.summary;
+    if (!summaryHtml) {
+      return {
+        source: 'maxpreps',
+        fetchedAt: new Date().toISOString(),
+        errors: fetchErrors,
+        team: null,
+        record: null,
+        stats: null,
+        schedule: [],
+        players: []
+      };
+    }
+
+    const summary = this.parseSummary(summaryHtml);
+    const schedule = includeSchedule
+      ? this.parseSchedule(summary.jsonLd, htmlResponses.schedule, summary.team?.name)
+      : [];
+    const players = includePlayerStats
+      ? this.parseRoster(htmlResponses.roster, summary.team?.name)
+      : [];
+
+    const stats = this.deriveTeamStats(summary.stats, schedule);
+
+    return {
+      source: 'maxpreps',
+      fetchedAt: new Date().toISOString(),
+      path: relativePath,
+      team: summary.team,
+      record: summary.record,
+      stats,
+      schedule,
+      players,
+      notes: summary.notes,
+      raw: {
+        structuredData: summary.jsonLd,
+        recordText: summary.recordText
+      },
+      errors: fetchErrors
+    };
+  }
+
+  parseSummary(html) {
+    const jsonLd = this.extractJsonLd(html);
+    const teamDoc = jsonLd.find((doc) => {
+      const types = Array.isArray(doc['@type']) ? doc['@type'] : [doc['@type']];
+      return types.includes('SportsTeam');
+    });
+
+    const teamName = this.normalizeText(teamDoc?.name) || this.extractTeamName(html);
+    const location = teamDoc?.address?.addressLocality || teamDoc?.location?.name || null;
+    const classification = this.extractClassification(html);
+    const district = this.extractDistrict(html);
+
+    const record = this.extractRecord(html);
+    const notes = this.extractNotes(html);
+    const stats = this.extractStatsFromJson(jsonLd, html);
+
+    return {
+      jsonLd,
+      team: {
+        name: teamName,
+        mascot: this.normalizeText(teamDoc?.alternateName),
+        slug: this.normalizeTeamPath(teamDoc?.url || teamDoc?.sameAs),
+        classification,
+        district,
+        location: this.normalizeText(location),
+        coach: this.extractCoach(html),
+        website: teamDoc?.url || null
+      },
+      record,
+      recordText: this.extractRecordText(html),
+      stats,
+      notes
+    };
+  }
+
+  extractTeamName(html) {
+    const match = html.match(/<h1[^>]*>(.*?)<\/h1>/i);
+    if (!match) return null;
+    return this.normalizeText(match[1]);
+  }
+
+  extractClassification(html) {
+    const match = html.match(/Classification[^A-Za-z0-9]*([A-Za-z0-9\s.-]+)/i);
+    return this.normalizeText(match?.[1]);
+  }
+
+  extractDistrict(html) {
+    const match = html.match(/District[^A-Za-z0-9]*([A-Za-z0-9\s.-]+)/i);
+    return this.normalizeText(match?.[1]);
+  }
+
+  extractCoach(html) {
+    const match = html.match(/Head Coach[^A-Za-z0-9]*([A-Za-z\s'.-]+)/i);
+    return this.normalizeText(match?.[1]);
+  }
+
+  extractRecord(html) {
+    const overallMatch = html.match(/Overall\s*(?:Record)?[^0-9]*([0-9]+-?[0-9]*-?[0-9]*)/i);
+    const districtMatch = html.match(/District\s*(?:Record)?[^0-9]*([0-9]+-?[0-9]*-?[0-9]*)/i);
+    const homeMatch = html.match(/Home\s*(?:Record)?[^0-9]*([0-9]+-?[0-9]*-?[0-9]*)/i);
+    const awayMatch = html.match(/Away\s*(?:Record)?[^0-9]*([0-9]+-?[0-9]*-?[0-9]*)/i);
+    const pfMatch = html.match(/Points\s*(?:For|Scored)[^0-9]*([0-9]+)/i);
+    const paMatch = html.match(/Points\s*(?:Against|Allowed)[^0-9]*([0-9]+)/i);
+    const stateRankMatch = html.match(/State\s*Rank[^0-9]*([0-9]+)/i);
+    const nationalRankMatch = html.match(/National\s*Rank[^0-9]*([0-9]+)/i);
+    const streakMatch = html.match(/Streak[^A-Za-z0-9]*([WL]-?\d+)/i);
+
+    return {
+      overall: parseRecordString(this, overallMatch?.[1]),
+      district: parseRecordString(this, districtMatch?.[1]),
+      home: parseRecordString(this, homeMatch?.[1]),
+      away: parseRecordString(this, awayMatch?.[1]),
+      stateRank: this.parseNumber(stateRankMatch?.[1]),
+      nationalRank: this.parseNumber(nationalRankMatch?.[1]),
+      pointsFor: this.parseNumber(pfMatch?.[1]),
+      pointsAgainst: this.parseNumber(paMatch?.[1]),
+      pointDifferential:
+        this.parseNumber(pfMatch?.[1]) !== null && this.parseNumber(paMatch?.[1]) !== null
+          ? this.parseNumber(pfMatch?.[1]) - this.parseNumber(paMatch?.[1])
+          : null,
+      streak: this.normalizeText(streakMatch?.[1])
+    };
+  }
+
+  extractRecordText(html) {
+    const match = html.match(/Overall\s*(?:Record)?[^<]*<[^>]*>[^<]*([0-9]+-?[0-9]*-?[0-9]*)/i);
+    return this.normalizeText(match?.[1]);
+  }
+
+  extractStatsFromJson(jsonLd, html) {
+    const statsDoc = jsonLd.find((doc) => {
+      const types = Array.isArray(doc['@type']) ? doc['@type'] : [doc['@type']];
+      return types.includes('Statistics');
+    });
+
+    const metrics = {};
+    if (statsDoc?.propertyID && statsDoc?.value) {
+      metrics[statsDoc.propertyID] = statsDoc.value;
+    }
+
+    if (Array.isArray(statsDoc?.statistics)) {
+      for (const stat of statsDoc.statistics) {
+        if (!stat) continue;
+        const key = stat.propertyID || stat.name;
+        if (!key) continue;
+        metrics[this.normalizeText(key).replace(/\s+/g, '_').toLowerCase()] = stat.value ?? stat.statValue ?? null;
+      }
+    }
+
+    // Attempt to capture additional metrics from HTML summary tables
+    const tableMatches = [...html.matchAll(/<th[^>]*>([^<]+)<\/th>\s*<td[^>]*>([^<]+)<\/td>/gi)];
+    for (const [, label, value] of tableMatches) {
+      const key = this.normalizeText(label).replace(/\s+/g, '_').toLowerCase();
+      if (key && !(key in metrics)) {
+        metrics[key] = this.parseNumber(value) ?? this.normalizeText(value);
+      }
+    }
+
+    return metrics;
+  }
+
+  extractNotes(html) {
+    const noteMatches = [...html.matchAll(/<li[^>]*class="[^"']*(?:note|insight)[^"']*"[^>]*>([\s\S]*?)<\/li>/gi)];
+    return noteMatches
+      .map(([, note]) => this.normalizeText(note.replace(/<[^>]+>/g, ' ')))
+      .filter(Boolean);
+  }
+
+  parseSchedule(structuredData = [], scheduleHtml, teamName) {
+    const schedule = [];
+
+    const docs = Array.isArray(structuredData) ? structuredData : [];
+    for (const doc of docs) {
+      if (!doc) continue;
+      const types = Array.isArray(doc['@type']) ? doc['@type'] : [doc['@type']];
+      if (!types.includes('SportsEvent')) continue;
+
+      const participants = this.resolveParticipants(doc, teamName);
+      if (!participants) continue;
+
+      schedule.push(participants);
+    }
+
+    if (schedule.length === 0 && scheduleHtml) {
+      schedule.push(...this.parseScheduleFromHtml(scheduleHtml, teamName));
+    }
+
+    return schedule;
+  }
+
+  resolveParticipants(eventDoc, teamName) {
+    const participants = [];
+    const allParticipants = [];
+
+    if (eventDoc.competitor) {
+      const list = Array.isArray(eventDoc.competitor) ? eventDoc.competitor : [eventDoc.competitor];
+      allParticipants.push(...list);
+    }
+
+    if (eventDoc.homeTeam) {
+      allParticipants.push({ ...eventDoc.homeTeam, homeAway: 'home' });
+    }
+
+    if (eventDoc.awayTeam) {
+      allParticipants.push({ ...eventDoc.awayTeam, homeAway: 'away' });
+    }
+
+    const normalizedTeamName = this.normalizeText(teamName);
+
+    let programParticipant = null;
+    for (const participant of allParticipants) {
+      const normalizedName = this.normalizeText(participant?.name);
+      if (normalizedName && normalizedTeamName && normalizedName.includes(normalizedTeamName)) {
+        programParticipant = participant;
+      } else {
+        participants.push({
+          name: this.normalizeText(participant?.name),
+          record: this.normalizeText(participant?.record),
+          classification: this.normalizeText(participant?.description)
+        });
+      }
+    }
+
+    const opponent = participants[0] || null;
+    const homeAway = programParticipant?.homeAway || (opponent?.homeAway === 'home' ? 'away' : opponent?.homeAway === 'away' ? 'home' : null);
+
+    return {
+      id: eventDoc.identifier || eventDoc['@id'] || null,
+      date: this.toDate(eventDoc.startDate || eventDoc.date),
+      endDate: this.toDate(eventDoc.endDate),
+      opponent: opponent?.name || null,
+      opponentDetails: opponent,
+      location: this.normalizeText(eventDoc.location?.name || eventDoc.location?.address?.addressLocality),
+      isHome: homeAway ? homeAway === 'home' : null,
+      venue: this.normalizeText(eventDoc.location?.name),
+      result: this.normalizeText(eventDoc.eventStatusText || eventDoc.eventStatus || eventDoc.result),
+      score: this.parseScore(eventDoc),
+      links: [eventDoc.url, eventDoc.sameAs].filter(Boolean)
+    };
+  }
+
+  parseScore(eventDoc) {
+    const teamScore = this.parseNumber(eventDoc.homeTeam?.score ?? eventDoc.homeScore ?? eventDoc.score);
+    const opponentScore = this.parseNumber(eventDoc.awayTeam?.score ?? eventDoc.awayScore ?? eventDoc.opponentScore);
+    const finalScore = this.normalizeText(eventDoc.finalScore || eventDoc.scoreSummary);
+
+    if (teamScore === null && opponentScore === null && !finalScore) {
+      return null;
+    }
+
+    return {
+      team: teamScore,
+      opponent: opponentScore,
+      summary: finalScore
+    };
+  }
+
+  parseScheduleFromHtml(html, teamName) {
+    if (!html) return [];
+    const rows = [...html.matchAll(/<tr[^>]*>([\s\S]*?)<\/tr>/gi)];
+    const schedule = [];
+    const normalizedTeamName = this.normalizeText(teamName);
+
+    for (const [, row] of rows) {
+      if (!/\d{1,2}\/\d{1,2}\/\d{2,4}/.test(row)) continue;
+      const columns = [...row.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/gi)].map(([, value]) =>
+        this.normalizeText(value.replace(/<[^>]+>/g, ' '))
+      );
+      if (columns.length < 3) continue;
+
+      const [dateText, opponentText, resultText, locationText] = columns;
+      const opponentName = opponentText?.replace(normalizedTeamName || '', '').trim();
+
+      schedule.push({
+        id: null,
+        date: this.toDate(dateText),
+        opponent: opponentName || opponentText || null,
+        location: locationText || null,
+        result: resultText || null,
+        score: this.parseScoreFromText(resultText)
+      });
+    }
+
+    return schedule;
+  }
+
+  parseScoreFromText(text) {
+    if (!text) return null;
+    const scoreMatch = text.match(/(\d+)\s*-\s*(\d+)/);
+    if (!scoreMatch) return { summary: text };
+    return {
+      team: this.parseNumber(scoreMatch[1]),
+      opponent: this.parseNumber(scoreMatch[2]),
+      summary: text
+    };
+  }
+
+  parseRoster(html, teamName) {
+    if (!html) return [];
+    const jsonLd = this.extractJsonLd(html);
+    const players = [];
+
+    for (const doc of jsonLd) {
+      if (!doc) continue;
+      const types = Array.isArray(doc['@type']) ? doc['@type'] : [doc['@type']];
+      if (!types.includes('Person')) continue;
+
+      players.push({
+        name: this.normalizeText(doc.name),
+        position: this.normalizeText(doc.memberOf?.roleName || doc.jobTitle || doc.position),
+        number: this.normalizeText(doc.memberOf?.identifier || doc.additionalName),
+        classYear: this.normalizeText(doc.award) || this.extractClassYear(doc.description),
+        height: this.normalizeText(doc.height),
+        weight: this.normalizeText(doc.weight),
+        hometown: this.normalizeText(doc.address?.addressLocality),
+        recruiting: null
+      });
+    }
+
+    if (players.length === 0) {
+      players.push(...this.parseRosterFromHtml(html, teamName));
+    }
+
+    return players;
+  }
+
+  extractClassYear(text) {
+    if (!text) return null;
+    const match = String(text).match(/Class\s*of\s*(\d{4})/i);
+    return match ? match[1] : null;
+  }
+
+  parseRosterFromHtml(html) {
+    const rows = [...html.matchAll(/<tr[^>]*>([\s\S]*?)<\/tr>/gi)];
+    const players = [];
+    for (const [, row] of rows) {
+      if (!/class/i.test(row)) continue;
+      const columns = [...row.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/gi)].map(([, value]) =>
+        this.normalizeText(value.replace(/<[^>]+>/g, ' '))
+      );
+      if (columns.length < 4) continue;
+      const [number, name, position, classYear, height, weight] = columns;
+      players.push({
+        name,
+        position,
+        number,
+        classYear,
+        height,
+        weight,
+        recruiting: null
+      });
+    }
+    return players;
+  }
+
+  deriveTeamStats(stats, schedule) {
+    const metrics = { ...stats };
+    const completedGames = schedule.filter((game) => game?.score && typeof game.score.team === 'number' && typeof game.score.opponent === 'number');
+
+    if (completedGames.length) {
+      const totals = completedGames.reduce(
+        (acc, game) => {
+          acc.pointsFor += game.score.team || 0;
+          acc.pointsAgainst += game.score.opponent || 0;
+          acc.games += 1;
+          return acc;
+        },
+        { pointsFor: 0, pointsAgainst: 0, games: 0 }
+      );
+
+      metrics.points_per_game = totals.games ? Number((totals.pointsFor / totals.games).toFixed(1)) : metrics.points_per_game || null;
+      metrics.points_allowed_per_game = totals.games ? Number((totals.pointsAgainst / totals.games).toFixed(1)) : metrics.points_allowed_per_game || null;
+      metrics.scoring_margin = totals.games ? Number(((totals.pointsFor - totals.pointsAgainst) / totals.games).toFixed(1)) : metrics.scoring_margin || null;
+    }
+
+    return metrics;
+  }
+}

--- a/services/highschool/rivalsAdapter.js
+++ b/services/highschool/rivalsAdapter.js
@@ -1,0 +1,328 @@
+import BaseAdapter from './baseAdapter.js';
+import { deepSearch, uniqueBy, truncate } from './utils.js';
+
+const COMMIT_STATUS_REGEX = /(commit|signed|enrolled|signee)/i;
+
+export default class RivalsAdapter extends BaseAdapter {
+  constructor(options = {}) {
+    super({
+      name: 'rivals',
+      baseUrl: 'https://n.rivals.com',
+      minRequestInterval: 750,
+      defaultHeaders: {
+        ...options.defaultHeaders,
+        'Accept-Language': 'en-US,en;q=0.9'
+      },
+      ...options
+    });
+  }
+
+  normalizeTeamPath(teamPath) {
+    if (!teamPath) return null;
+    return teamPath
+      .replace(/^https?:\/\/[^/]+\//i, '')
+      .replace(/^\//, '')
+      .replace(/\/$/, '');
+  }
+
+  async getRecruitingData({
+    teamPath,
+    includeTargets = true,
+    season
+  }) {
+    const normalizedPath = this.normalizeTeamPath(teamPath);
+    if (!normalizedPath) {
+      throw new Error('[rivals] teamPath is required to fetch recruiting data');
+    }
+
+    const html = await this.fetchHtml(normalizedPath, {
+      searchParams: season ? { season } : undefined
+    });
+
+    const nuxtData = this.extractScriptJson(html, [
+      { pattern: 'window\\.__NUXT__\\s*=\\s*([\\s\\S]*?);', flags: 'i' },
+      '__NUXT__'
+    ]);
+    const jsonLd = this.extractJsonLd(html);
+
+    const team = this.parseTeam(nuxtData, jsonLd, html);
+    const commits = this.extractProspects(nuxtData, html, { committedOnly: true });
+    const targets = includeTargets ? this.extractProspects(nuxtData, html, { committedOnly: false }) : [];
+    const rankings = this.extractRankings(nuxtData, html);
+    const headlines = this.extractHeadlines(html);
+
+    return {
+      source: 'rivals',
+      fetchedAt: new Date().toISOString(),
+      team,
+      recruiting: {
+        commits,
+        targets,
+        rankings: rankings?.metrics || null,
+        summary: this.buildSummary(commits, rankings)
+      },
+      notes: headlines,
+      raw: {
+        structuredData: jsonLd,
+        rankingSource: rankings?.rawSnippet || null
+      },
+      errors: rankings?.errors || []
+    };
+  }
+
+  parseTeam(nuxtData, jsonLd, html) {
+    const teamDoc = (jsonLd || []).find((doc) => {
+      const types = Array.isArray(doc['@type']) ? doc['@type'] : [doc['@type']];
+      return types.includes('SportsTeam') || types.includes('Organization');
+    });
+
+    const teamNodes = deepSearch(nuxtData, (node) =>
+      node && typeof node === 'object' && (
+        node.teamName || node.schoolName || node.programName || node.nickname
+      )
+    );
+    const teamNode = teamNodes[0] || {};
+
+    return {
+      name: this.normalizeText(teamDoc?.name || teamNode.teamName || teamNode.programName || this.extractHeading(html)),
+      mascot: this.normalizeText(teamNode.nickname || teamDoc?.alternateName),
+      classification: this.normalizeText(teamNode.level || teamNode.classification),
+      state: this.normalizeText(teamNode.state || teamDoc?.address?.addressRegion),
+      city: this.normalizeText(teamNode.city || teamDoc?.address?.addressLocality),
+      record: {
+        overall: this.normalizeText(teamNode.overallRecord || teamNode.record),
+        district: this.normalizeText(teamNode.districtRecord)
+      },
+      rankings: {
+        national: this.parseNumber(teamNode.nationalRank),
+        state: this.parseNumber(teamNode.stateRank)
+      },
+      profileUrl: teamNode.url || teamDoc?.url || null
+    };
+  }
+
+  extractHeading(html) {
+    const match = html.match(/<h1[^>]*>(.*?)<\/h1>/i);
+    return this.normalizeText(match?.[1]);
+  }
+
+  extractProspects(nuxtData, html, { committedOnly }) {
+    const nodes = deepSearch(nuxtData, (node) =>
+      node && typeof node === 'object' && (
+        'athleteName' in node ||
+        'prospectName' in node ||
+        'playerName' in node ||
+        ('name' in node && ('rating' in node || 'rivalsRating' in node || 'position' in node))
+      )
+    );
+
+    const prospects = nodes
+      .map((node) => this.mapProspect(node))
+      .filter(Boolean)
+      .filter((prospect) => {
+        if (!prospect?.name) return false;
+        if (!committedOnly) return true;
+        return COMMIT_STATUS_REGEX.test(prospect.status || '');
+      });
+
+    const unique = uniqueBy(prospects, (prospect) => `${prospect.name}-${prospect.classYear || ''}`);
+
+    if (unique.length) {
+      return unique;
+    }
+
+    return this.parseProspectsFromHtml(html, { committedOnly });
+  }
+
+  mapProspect(node) {
+    if (!node || typeof node !== 'object') return null;
+
+    const name = this.normalizeText(
+      node.athleteName || node.prospectName || node.playerName || node.name
+    );
+
+    if (!name) return null;
+
+    const position = this.normalizeText(
+      node.position || node.primaryPosition || node.positionAbbr || node.positionShort
+    );
+    const height = this.normalizeText(node.height || node.playerHeight);
+    const weight = this.parseNumber(node.weight || node.playerWeight);
+    const rating = this.parseNumber(node.rivalsRating || node.rating || node.rankingPoints);
+    const stars = this.parseNumber(node.stars || node.starRating);
+
+    const status = this.normalizeText(node.commitmentStatus || node.status || node.commitStatus);
+    const commitDate = this.toDate(node.commitDate || node.updatedAt || node.decisionDate);
+    const classYear = this.normalizeText(node.class || node.classYear || node.gradYear);
+
+    const nationalRank = this.parseNumber(node.nationalRank || node.nationalRanking);
+    const stateRank = this.parseNumber(node.stateRank || node.stateRanking);
+    const positionRank = this.parseNumber(node.positionRank || node.positionRanking);
+
+    const hometown = this.normalizeText(node.hometown || node.cityState || node.highSchool);
+
+    return {
+      name,
+      position,
+      classYear,
+      status,
+      commitmentDate: commitDate,
+      measurables: {
+        height,
+        weight
+      },
+      hometown,
+      ranking: {
+        national: nationalRank,
+        state: stateRank,
+        position: positionRank
+      },
+      rating,
+      stars,
+      profileUrl: node.profileUrl || node.url || null
+    };
+  }
+
+  parseProspectsFromHtml(html, { committedOnly }) {
+    if (!html) return [];
+    const rows = [...html.matchAll(/<tr[^>]*>([\s\S]*?)<\/tr>/gi)];
+    const prospects = [];
+
+    for (const [, row] of rows) {
+      if (!/(?:Commit|Target|Interest)/i.test(row)) continue;
+      const cells = [...row.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/gi)].map(([, value]) =>
+        this.normalizeText(value.replace(/<[^>]+>/g, ' '))
+      );
+      if (cells.length < 5) continue;
+
+      const [name, position, measurables, hometown, status] = cells;
+      if (!name) continue;
+
+      if (committedOnly && !COMMIT_STATUS_REGEX.test(status || '')) {
+        continue;
+      }
+
+      const ratingMatch = row.match(/data-rating="([0-9.]+)"/i);
+      const starsMatch = row.match(/data-stars="([0-9.]+)"/i);
+
+      prospects.push({
+        name,
+        position,
+        classYear: null,
+        status,
+        commitmentDate: null,
+        measurables: {
+          height: measurables?.split('/')[0]?.trim() || null,
+          weight: this.parseNumber(measurables?.split('/')[1])
+        },
+        hometown,
+        ranking: {
+          national: null,
+          state: null,
+          position: null
+        },
+        rating: this.parseNumber(ratingMatch?.[1]),
+        stars: this.parseNumber(starsMatch?.[1]),
+        profileUrl: null
+      });
+    }
+
+    return prospects;
+  }
+
+  extractRankings(nuxtData, html) {
+    const rankingNodes = deepSearch(nuxtData, (node) =>
+      node && typeof node === 'object' && (
+        ('teamRank' in node && 'rankingPoints' in node) ||
+        ('teamRanking' in node && typeof node.teamRanking === 'object') ||
+        ('teamScore' in node && 'nationalRank' in node)
+      )
+    );
+
+    const metrics = rankingNodes.map((node) => this.mapRanking(node)).filter(Boolean);
+
+    if (metrics.length) {
+      const best = metrics.sort((a, b) => (a.timestamp || 0) < (b.timestamp || 0) ? 1 : -1)[0];
+      return { metrics: best, rawSnippet: truncate(JSON.stringify(best)) };
+    }
+
+    const fallback = this.extractRankingsFromHtml(html);
+    return {
+      metrics: fallback,
+      rawSnippet: fallback ? truncate(JSON.stringify(fallback)) : null,
+      errors: []
+    };
+  }
+
+  mapRanking(node) {
+    if (!node || typeof node !== 'object') return null;
+    const ranking = node.teamRanking || node.ranking || node;
+    const timestamp = ranking.updatedAt || node.timestamp || null;
+
+    return {
+      nationalRank: this.parseNumber(ranking.nationalRank || ranking.teamRank || ranking.rank),
+      stateRank: this.parseNumber(ranking.stateRank || ranking.rankState),
+      classRank: this.parseNumber(ranking.classRank || ranking.rankClass),
+      compositeScore: this.parseNumber(ranking.teamScore || ranking.rankingPoints || ranking.points),
+      averageRating: this.parseNumber(ranking.averageRating || ranking.avgStars || ranking.avgRating),
+      totalCommits: this.parseNumber(ranking.totalCommits || ranking.commitments || ranking.pledges),
+      blueChips: this.parseNumber(ranking.blueChips || ranking.fourStarPlus || ranking.topPlayers),
+      timestamp: timestamp ? this.toDate(timestamp) : null
+    };
+  }
+
+  extractRankingsFromHtml(html) {
+    if (!html) return null;
+    const nationalMatch = html.match(/National\s*Rank[^0-9]*([0-9]+)/i);
+    const stateMatch = html.match(/State\s*Rank[^0-9]*([0-9]+)/i);
+    const classMatch = html.match(/Class\s*Rank[^0-9]*([0-9]+)/i);
+    const scoreMatch = html.match(/Points[^0-9]*([0-9.]+)/i);
+
+    if (!nationalMatch && !stateMatch && !classMatch && !scoreMatch) {
+      return null;
+    }
+
+    return {
+      nationalRank: this.parseNumber(nationalMatch?.[1]),
+      stateRank: this.parseNumber(stateMatch?.[1]),
+      classRank: this.parseNumber(classMatch?.[1]),
+      compositeScore: this.parseNumber(scoreMatch?.[1]),
+      averageRating: null,
+      totalCommits: null,
+      blueChips: null,
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  extractHeadlines(html) {
+    if (!html) return [];
+    const items = [...html.matchAll(/<a[^>]*class="[^"]*(?:headline|title)[^"]*"[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi)];
+    return items.slice(0, 5).map(([, href, title]) => ({
+      title: this.normalizeText(title.replace(/<[^>]+>/g, ' ')),
+      url: href.startsWith('http') ? href : `https://n.rivals.com${href}`
+    }));
+  }
+
+  buildSummary(commits, rankings) {
+    const totalCommits = commits.length;
+    const averageRating = commits.length
+      ? Number(
+          (
+            commits
+              .map((prospect) => prospect.rating || 0)
+              .filter((rating) => typeof rating === 'number')
+              .reduce((acc, curr) => acc + curr, 0) / commits.length
+          ).toFixed(3)
+        )
+      : null;
+
+    return {
+      totalCommits,
+      averageRating,
+      nationalRank: rankings?.metrics?.nationalRank || null,
+      stateRank: rankings?.metrics?.stateRank || null,
+      classRank: rankings?.metrics?.classRank || null,
+      compositeScore: rankings?.metrics?.compositeScore || null
+    };
+  }
+}

--- a/services/highschool/texasHighSchoolFootballService.js
+++ b/services/highschool/texasHighSchoolFootballService.js
@@ -1,0 +1,328 @@
+import MaxPrepsAdapter from './maxprepsAdapter.js';
+import TwentyFourSevenSportsAdapter from './twentyFourSevenSportsAdapter.js';
+import RivalsAdapter from './rivalsAdapter.js';
+import { uniqueBy } from './utils.js';
+
+export default class TexasHighSchoolFootballService {
+  constructor(options = {}) {
+    const {
+      cacheTtl = 15 * 60 * 1000,
+      adapters = {},
+      sources = {}
+    } = options;
+
+    this.adapters = {
+      maxpreps: adapters.maxpreps || new MaxPrepsAdapter(sources.maxpreps || {}),
+      twentyFourSeven: adapters.twentyFourSeven || new TwentyFourSevenSportsAdapter(sources.twentyFourSeven || {}),
+      rivals: adapters.rivals || new RivalsAdapter(sources.rivals || {})
+    };
+
+    this.cache = new Map();
+    this.cacheTtl = cacheTtl;
+  }
+
+  createCacheKey(params) {
+    const entries = Object.entries(params)
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => [key, value])
+      .sort(([a], [b]) => a.localeCompare(b));
+    return JSON.stringify(entries);
+  }
+
+  getFromCache(key) {
+    const cached = this.cache.get(key);
+    if (!cached) return null;
+    if (cached.expires < Date.now()) {
+      this.cache.delete(key);
+      return null;
+    }
+    return cached.value;
+  }
+
+  setCache(key, value) {
+    this.cache.set(key, {
+      value,
+      expires: Date.now() + this.cacheTtl
+    });
+  }
+
+  async getProgramData({
+    team,
+    season,
+    maxprepsTeamPath,
+    maxprepsTeamId,
+    twentyFourSevenTeamPath,
+    rivalsTeamPath,
+    includeSchedule = true,
+    includePlayerStats = true,
+    includeRecruiting = true,
+    includeRaw = false,
+    forceRefresh = false
+  }) {
+    const cacheKey = this.createCacheKey({
+      team,
+      season,
+      maxprepsTeamPath,
+      maxprepsTeamId,
+      twentyFourSevenTeamPath,
+      rivalsTeamPath,
+      includeSchedule,
+      includePlayerStats,
+      includeRecruiting,
+      includeRaw
+    });
+
+    if (!forceRefresh) {
+      const cached = this.getFromCache(cacheKey);
+      if (cached) {
+        return { ...cached, metadata: { ...cached.metadata, cache: { hit: true, generatedAt: cached.metadata.generatedAt } } };
+      }
+    }
+
+    const fetchResults = {};
+    const errors = [];
+
+    if (this.adapters.maxpreps && (maxprepsTeamPath || maxprepsTeamId)) {
+      try {
+        fetchResults.maxpreps = await this.adapters.maxpreps.getTeamData({
+          teamPath: maxprepsTeamPath,
+          teamId: maxprepsTeamId,
+          season,
+          includeSchedule,
+          includePlayerStats
+        });
+      } catch (error) {
+        errors.push({ source: 'maxpreps', message: error.message });
+      }
+    }
+
+    if (includeRecruiting && this.adapters.twentyFourSeven && twentyFourSevenTeamPath) {
+      try {
+        fetchResults.twentyFourSeven = await this.adapters.twentyFourSeven.getRecruitingData({
+          teamPath: twentyFourSevenTeamPath,
+          season,
+          includeTargets: true
+        });
+      } catch (error) {
+        errors.push({ source: '247sports', message: error.message });
+      }
+    }
+
+    if (includeRecruiting && this.adapters.rivals && rivalsTeamPath) {
+      try {
+        fetchResults.rivals = await this.adapters.rivals.getRecruitingData({
+          teamPath: rivalsTeamPath,
+          season,
+          includeTargets: true
+        });
+      } catch (error) {
+        errors.push({ source: 'rivals', message: error.message });
+      }
+    }
+
+    const normalized = this.combineResults({
+      team,
+      season,
+      includeRaw,
+      results: fetchResults,
+      errors
+    });
+
+    this.setCache(cacheKey, normalized);
+
+    return normalized;
+  }
+
+  combineResults({ team, season, includeRaw, results, errors }) {
+    const maxpreps = results.maxpreps || {};
+    const s247 = results.twentyFourSeven || {};
+    const rivals = results.rivals || {};
+
+    const programName = maxpreps.team?.name || s247.team?.name || rivals.team?.name || team || null;
+
+    const metadata = {
+      team: programName,
+      requestedTeam: team || null,
+      season: season || null,
+      generatedAt: new Date().toISOString(),
+      sources: [
+        maxpreps.source ? { name: 'maxpreps', fetchedAt: maxpreps.fetchedAt } : null,
+        s247.source ? { name: '247sports', fetchedAt: s247.fetchedAt } : null,
+        rivals.source ? { name: 'rivals', fetchedAt: rivals.fetchedAt } : null
+      ].filter(Boolean)
+    };
+
+    const schedule = maxpreps.schedule || [];
+    const players = maxpreps.players || [];
+    const record = maxpreps.record || {};
+    const stats = maxpreps.stats || {};
+
+    const recruiting = this.mergeRecruiting({
+      s247: s247.recruiting,
+      rivals: rivals.recruiting
+    });
+
+    const insights = this.generateInsights({ record, stats, schedule, recruiting });
+
+    const payload = {
+      metadata,
+      teamProfile: {
+        name: programName,
+        classification: maxpreps.team?.classification || s247.team?.classification || rivals.team?.classification || null,
+        district: maxpreps.team?.district || null,
+        location: maxpreps.team?.location || s247.team?.city || rivals.team?.city || null,
+        coach: maxpreps.team?.coach || null,
+        record,
+        rankings: this.mergeRankings(maxpreps.record, recruiting.rankings)
+      },
+      performance: {
+        stats,
+        notes: maxpreps.notes || []
+      },
+      schedule,
+      players,
+      recruiting,
+      insights,
+      errors
+    };
+
+    if (includeRaw) {
+      payload.sources = {
+        maxpreps: maxpreps.raw || null,
+        twentyFourSeven: s247.raw || null,
+        rivals: rivals.raw || null
+      };
+    }
+
+    return payload;
+  }
+
+  mergeRecruiting({ s247, rivals }) {
+    const commits = uniqueBy(
+      [
+        ...(s247?.commits || []),
+        ...(rivals?.commits || [])
+      ],
+      (prospect) => `${prospect.name}-${prospect.classYear || ''}`
+    );
+
+    const targets = uniqueBy(
+      [
+        ...(s247?.targets || []),
+        ...(rivals?.targets || [])
+      ],
+      (prospect) => `${prospect.name}-${prospect.classYear || ''}`
+    );
+
+    const rankings = {
+      bySource: {
+        s247: s247?.rankings || null,
+        rivals: rivals?.rankings || null
+      },
+      consensus: this.calculateConsensusRankings(s247?.rankings, rivals?.rankings)
+    };
+
+    const summary = {
+      totalCommits: commits.length,
+      averageRating: this.calculateAverageRating(commits),
+      consensusNationalRank: rankings.consensus?.nationalRank || null,
+      consensusStateRank: rankings.consensus?.stateRank || null
+    };
+
+    return {
+      commits,
+      targets,
+      rankings,
+      summary
+    };
+  }
+
+  calculateAverageRating(commits) {
+    if (!commits?.length) return null;
+    const ratings = commits
+      .map((prospect) => prospect.rating)
+      .filter((rating) => typeof rating === 'number');
+    if (!ratings.length) return null;
+    const total = ratings.reduce((acc, value) => acc + value, 0);
+    return Number((total / ratings.length).toFixed(3));
+  }
+
+  calculateConsensusRankings(s247Rankings, rivalsRankings) {
+    const ranks = {
+      national: [s247Rankings?.nationalRank, rivalsRankings?.nationalRank],
+      state: [s247Rankings?.stateRank, rivalsRankings?.stateRank],
+      class: [s247Rankings?.classRank, rivalsRankings?.classRank]
+    };
+
+    const parse = (values) => {
+      const filtered = values.filter((value) => typeof value === 'number');
+      if (!filtered.length) return null;
+      return Math.min(...filtered);
+    };
+
+    const compositeScore = [
+      s247Rankings?.compositeScore,
+      rivalsRankings?.compositeScore
+    ].filter((value) => typeof value === 'number');
+
+    return {
+      nationalRank: parse(ranks.national),
+      stateRank: parse(ranks.state),
+      classRank: parse(ranks.class),
+      compositeScore: compositeScore.length ? Number((compositeScore.reduce((acc, value) => acc + value, 0) / compositeScore.length).toFixed(3)) : null
+    };
+  }
+
+  mergeRankings(record, recruitingRankings) {
+    return {
+      state: record?.stateRank || recruitingRankings?.consensus?.stateRank || null,
+      national: record?.nationalRank || recruitingRankings?.consensus?.nationalRank || null,
+      recruiting: recruitingRankings?.consensus || null
+    };
+  }
+
+  generateInsights({ record, stats, schedule, recruiting }) {
+    const quickHits = [];
+    const metrics = {};
+
+    if (record?.overall?.wins !== undefined && record?.overall?.losses !== undefined) {
+      quickHits.push(`Overall record: ${record.overall.wins}-${record.overall.losses}${record.overall.ties ? `-${record.overall.ties}` : ''}`);
+    }
+
+    if (typeof stats.points_per_game === 'number') {
+      quickHits.push(`Offense averaging ${stats.points_per_game} points per game.`);
+      metrics.pointsPerGame = stats.points_per_game;
+    }
+
+    if (typeof stats.points_allowed_per_game === 'number') {
+      quickHits.push(`Defense allowing ${stats.points_allowed_per_game} points per game.`);
+      metrics.pointsAllowedPerGame = stats.points_allowed_per_game;
+    }
+
+    if (schedule?.length) {
+      const completed = schedule.filter((game) => game?.score && typeof game.score.team === 'number' && typeof game.score.opponent === 'number');
+      if (completed.length >= 2) {
+        const lastTwo = completed.slice(-2);
+        const diff = lastTwo.reduce((acc, game) => acc + (game.score.team - game.score.opponent), 0);
+        if (diff > 0) {
+          quickHits.push('Team enters the week on a positive scoring margin over the last two games.');
+        }
+        metrics.recentPointDifferential = diff;
+      }
+    }
+
+    if (recruiting?.summary?.totalCommits) {
+      quickHits.push(`Recruiting class holds ${recruiting.summary.totalCommits} verbal commitments.`);
+      metrics.totalCommits = recruiting.summary.totalCommits;
+    }
+
+    if (typeof recruiting?.summary?.consensusNationalRank === 'number') {
+      quickHits.push(`Consensus national recruiting rank: ${recruiting.summary.consensusNationalRank}.`);
+    }
+
+    return {
+      quickHits,
+      metrics
+    };
+  }
+}

--- a/services/highschool/twentyFourSevenSportsAdapter.js
+++ b/services/highschool/twentyFourSevenSportsAdapter.js
@@ -1,0 +1,329 @@
+import BaseAdapter from './baseAdapter.js';
+import { deepSearch, uniqueBy, truncate } from './utils.js';
+
+export default class TwentyFourSevenSportsAdapter extends BaseAdapter {
+  constructor(options = {}) {
+    super({
+      name: '247sports',
+      baseUrl: 'https://247sports.com',
+      minRequestInterval: 750,
+      ...options
+    });
+  }
+
+  normalizeTeamPath(teamPath) {
+    if (!teamPath) return null;
+    return teamPath
+      .replace(/^https?:\/\/[^/]+\//i, '')
+      .replace(/^\//, '')
+      .replace(/\/$/, '');
+  }
+
+  async getRecruitingData({
+    teamPath,
+    season,
+    includeTargets = true
+  }) {
+    const normalizedPath = this.normalizeTeamPath(teamPath);
+    if (!normalizedPath) {
+      throw new Error('[247sports] teamPath is required to fetch recruiting data');
+    }
+
+    const html = await this.fetchHtml(normalizedPath, {
+      searchParams: season ? { season } : undefined
+    });
+
+    const nextData = this.extractScriptJson(html, [{ id: '__NEXT_DATA__' }, '__NEXT_DATA__']);
+    const jsonLd = this.extractJsonLd(html);
+
+    const team = this.parseTeam(nextData, jsonLd, html);
+    const commits = this.extractProspects(nextData, html, { committedOnly: true });
+    const targets = includeTargets ? this.extractProspects(nextData, html, { committedOnly: false }) : [];
+    const rankings = this.extractRankings(nextData, html);
+    const news = this.extractNews(html);
+
+    const summary = this.buildSummary(commits, rankings);
+
+    return {
+      source: '247sports',
+      fetchedAt: new Date().toISOString(),
+      team,
+      recruiting: {
+        commits,
+        targets,
+        rankings: rankings?.metrics || null,
+        summary
+      },
+      notes: news,
+      raw: {
+        structuredData: jsonLd,
+        rankingSource: rankings?.rawSnippet || null
+      },
+      errors: rankings?.errors || []
+    };
+  }
+
+  parseTeam(nextData, jsonLd, html) {
+    const teamDoc = (jsonLd || []).find((doc) => {
+      const types = Array.isArray(doc['@type']) ? doc['@type'] : [doc['@type']];
+      return types.includes('SportsTeam') || types.includes('Organization');
+    });
+
+    const nameFromHtml = this.extractHeading(html);
+
+    const teamNodeCandidates = deepSearch(nextData, (node) =>
+      node && typeof node === 'object' && (node.teamName || node.schoolName || node.fullName)
+    );
+    const teamNode = teamNodeCandidates[0] || {};
+
+    return {
+      name: this.normalizeText(teamDoc?.name || teamNode.teamName || teamNode.schoolName || nameFromHtml),
+      mascot: this.normalizeText(teamDoc?.alternateName || teamNode.mascot),
+      classification: this.normalizeText(teamNode.classification || teamNode.level),
+      state: this.normalizeText(teamNode.state || teamDoc?.address?.addressRegion),
+      city: this.normalizeText(teamNode.city || teamDoc?.address?.addressLocality),
+      record: {
+        overall: this.normalizeText(teamNode.overallRecord || teamNode.record),
+        district: this.normalizeText(teamNode.districtRecord)
+      },
+      rankings: {
+        national: this.parseNumber(teamNode.nationalRank),
+        state: this.parseNumber(teamNode.stateRank)
+      },
+      profileUrl: teamNode.teamUrl || teamNode.url || teamDoc?.url || null
+    };
+  }
+
+  extractHeading(html) {
+    const match = html.match(/<h1[^>]*>(.*?)<\/h1>/i);
+    return this.normalizeText(match?.[1]);
+  }
+
+  extractProspects(nextData, html, { committedOnly }) {
+    const nodes = deepSearch(nextData, (node) =>
+      node && typeof node === 'object' && (
+        'prospectName' in node ||
+        'playerName' in node ||
+        'fullName' in node ||
+        ('name' in node && ('position' in node || 'rating' in node || 'compositeRating' in node))
+      )
+    );
+
+    const mapped = nodes.map((node) => this.mapProspect(node)).filter(Boolean);
+    const filtered = mapped.filter((prospect) => {
+      if (!prospect?.name) return false;
+      if (!committedOnly) return true;
+      return /(commit|signed|enrolled)/i.test(prospect.status || '');
+    });
+
+    const unique = uniqueBy(filtered, (prospect) => `${prospect.name}-${prospect.classYear || ''}`);
+
+    if (unique.length > 0) {
+      return unique;
+    }
+
+    // Fallback to parsing HTML tables when Next.js data is not accessible
+    return this.parseProspectsFromHtml(html, { committedOnly });
+  }
+
+  mapProspect(node) {
+    if (!node || typeof node !== 'object') return null;
+
+    const name = this.normalizeText(
+      node.prospectName || node.playerName || node.fullName || node.name
+    );
+
+    if (!name) return null;
+
+    const position = this.normalizeText(
+      node.position ||
+        node.primaryPosition?.abbreviation ||
+        node.primaryPosition?.name ||
+        node.pos ||
+        node.positionGroup
+    );
+
+    const height = this.normalizeText(node.height || node.ht || node.playerHeight);
+    const weight = this.parseNumber(node.weight || node.wt || node.playerWeight);
+    const rating = this.parseNumber(node.compositeRating || node.rating || node.score || node.overallRating);
+    const stars = this.parseNumber(node.stars || node.starRating || node.averageStars);
+
+    const hometown = this.normalizeText(
+      node.hometown || node.homeTown || node.highSchool || node.school || node.origin
+    );
+
+    const commitmentStatus = this.normalizeText(node.status || node.commitmentStatus || node.decisionStatus);
+    const commitmentDate = this.toDate(node.commitDate || node.commitmentDate || node.decisionDate);
+
+    const classYear = this.normalizeText(node.class || node.classYear || node.recruitClass);
+    const nationalRank = this.parseNumber(node.nationalRank || node.natRank || node.rankNational);
+    const stateRank = this.parseNumber(node.stateRank || node.stateRanking || node.rankState);
+    const positionRank = this.parseNumber(node.positionRank || node.posRank || node.rankPosition);
+
+    return {
+      name,
+      position,
+      classYear,
+      status: commitmentStatus,
+      commitmentDate,
+      measurables: {
+        height,
+        weight
+      },
+      hometown,
+      ranking: {
+        national: nationalRank,
+        state: stateRank,
+        position: positionRank
+      },
+      rating,
+      stars,
+      profileUrl: node.profileUrl || node.playerProfileUrl || node.url || null
+    };
+  }
+
+  parseProspectsFromHtml(html, { committedOnly }) {
+    if (!html) return [];
+    const rows = [...html.matchAll(/<tr[^>]*>([\s\S]*?)<\/tr>/gi)];
+    const prospects = [];
+
+    for (const [, row] of rows) {
+      if (!/(?:Commit|Target|Interest)/i.test(row)) continue;
+      const cells = [...row.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/gi)].map(([, value]) =>
+        this.normalizeText(value.replace(/<[^>]+>/g, ' '))
+      );
+      if (cells.length < 5) continue;
+
+      const [name, position, measurables, hometown, status] = cells;
+      if (!name) continue;
+
+      if (committedOnly && !/(?:Commit|Signed|Enrolled)/i.test(status)) {
+        continue;
+      }
+
+      const ratingMatch = row.match(/data-rating="([0-9.]+)"/i);
+      const starsMatch = row.match(/data-stars="([0-9.]+)"/i);
+
+      prospects.push({
+        name,
+        position,
+        classYear: null,
+        status,
+        commitmentDate: null,
+        measurables: {
+          height: measurables?.split('/')[0]?.trim() || null,
+          weight: this.parseNumber(measurables?.split('/')[1])
+        },
+        hometown,
+        ranking: {
+          national: null,
+          state: null,
+          position: null
+        },
+        rating: this.parseNumber(ratingMatch?.[1]),
+        stars: this.parseNumber(starsMatch?.[1]),
+        profileUrl: null
+      });
+    }
+
+    return prospects;
+  }
+
+  extractRankings(nextData, html) {
+    const rankingNodes = deepSearch(nextData, (node) =>
+      node && typeof node === 'object' && (
+        ('nationalRank' in node && 'stateRank' in node) ||
+        ('teamScore' in node && 'rank' in node) ||
+        ('ranking' in node && typeof node.ranking === 'object')
+      )
+    );
+
+    const metrics = rankingNodes.map((node) => this.mapRanking(node)).filter(Boolean);
+
+    if (metrics.length) {
+      const best = metrics.sort((a, b) => (a.timestamp || 0) < (b.timestamp || 0) ? 1 : -1)[0];
+      return { metrics: best, rawSnippet: truncate(JSON.stringify(best)) };
+    }
+
+    // Fallback to HTML parsing
+    const fallback = this.extractRankingsFromHtml(html);
+    return {
+      metrics: fallback,
+      rawSnippet: fallback ? truncate(JSON.stringify(fallback)) : null,
+      errors: []
+    };
+  }
+
+  mapRanking(node) {
+    if (!node || typeof node !== 'object') return null;
+    const ranking = node.ranking || node;
+    const timestamp = ranking.updatedAt || ranking.lastUpdated || node.timestamp || null;
+
+    return {
+      nationalRank: this.parseNumber(ranking.nationalRank || ranking.national || ranking.natRank || ranking.rank),
+      stateRank: this.parseNumber(ranking.stateRank || ranking.state || ranking.rankState),
+      classRank: this.parseNumber(ranking.classRank || ranking.classificationRank || ranking.rankClass),
+      compositeScore: this.parseNumber(ranking.teamScore || ranking.points || ranking.score),
+      averageRating: this.parseNumber(ranking.avgRating || ranking.averageRating || ranking.averageScore),
+      totalCommits: this.parseNumber(ranking.totalCommits || ranking.commitments || ranking.totalRecruits),
+      blueChips: this.parseNumber(ranking.blueChips || ranking.fourStarPlus || ranking.blueChipCount),
+      timestamp: timestamp ? this.toDate(timestamp) : null
+    };
+  }
+
+  extractRankingsFromHtml(html) {
+    if (!html) return null;
+    const nationalMatch = html.match(/National\s*Rank[^0-9]*([0-9]+)/i);
+    const stateMatch = html.match(/State\s*Rank[^0-9]*([0-9]+)/i);
+    const classMatch = html.match(/Class\s*Rank[^0-9]*([0-9]+)/i);
+    const scoreMatch = html.match(/Composite\s*Score[^0-9]*([0-9.]+)/i);
+
+    if (!nationalMatch && !stateMatch && !classMatch && !scoreMatch) {
+      return null;
+    }
+
+    return {
+      nationalRank: this.parseNumber(nationalMatch?.[1]),
+      stateRank: this.parseNumber(stateMatch?.[1]),
+      classRank: this.parseNumber(classMatch?.[1]),
+      compositeScore: this.parseNumber(scoreMatch?.[1]),
+      averageRating: null,
+      totalCommits: null,
+      blueChips: null,
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  extractNews(html) {
+    if (!html) return [];
+    const articles = [...html.matchAll(/<article[\s\S]*?<a[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>[\s\S]*?<time[^>]*>([^<]*)<\/time>/gi)];
+    return articles.slice(0, 5).map(([, href, title, date]) => ({
+      title: this.normalizeText(title.replace(/<[^>]+>/g, ' ')),
+      url: href.startsWith('http') ? href : `https://247sports.com${href}`,
+      publishedAt: this.toDate(date)
+    }));
+  }
+
+  buildSummary(commits, rankings) {
+    const totalCommits = commits.length;
+    const averageRating = commits.length
+      ? Number(
+          (
+            commits
+              .map((prospect) => prospect.rating || 0)
+              .filter((rating) => typeof rating === 'number')
+              .reduce((acc, curr) => acc + curr, 0) / commits.length
+          ).toFixed(3)
+        )
+      : null;
+
+    return {
+      totalCommits,
+      averageRating,
+      nationalRank: rankings?.metrics?.nationalRank || null,
+      stateRank: rankings?.metrics?.stateRank || null,
+      classRank: rankings?.metrics?.classRank || null,
+      compositeScore: rankings?.metrics?.compositeScore || null
+    };
+  }
+}

--- a/services/highschool/utils.js
+++ b/services/highschool/utils.js
@@ -1,0 +1,36 @@
+export function deepSearch(value, predicate, results = [], visited = new WeakSet()) {
+  if (!value || typeof value !== 'object') return results;
+  if (visited.has(value)) return results;
+  visited.add(value);
+
+  if (predicate(value)) {
+    results.push(value);
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      deepSearch(item, predicate, results, visited);
+    }
+  } else {
+    for (const key of Object.keys(value)) {
+      deepSearch(value[key], predicate, results, visited);
+    }
+  }
+
+  return results;
+}
+
+export function uniqueBy(array, keyFn) {
+  const seen = new Set();
+  return array.filter((item) => {
+    const key = keyFn(item);
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function truncate(value, limit = 6000) {
+  if (!value) return null;
+  return value.length > limit ? `${value.slice(0, limit)}…` : value;
+}


### PR DESCRIPTION
## Summary
- add a high school scraping adapter layer with shared HTTP utilities
- implement MaxPreps, 247Sports, and Rivals connectors plus a Texas HS aggregation service
- expose `/api/texas-hs-football/program` and document usage in the README

## Testing
- node -e "import('./services/highschool/texasHighSchoolFootballService.js').then(() => console.log('service ok'))"

------
https://chatgpt.com/codex/tasks/task_e_68cc3c42cd5c8330a103f39f98f8ef0f