### PR TITLE
Add Texas Longhorns MCP server for football and baseball data

### DIFF
--- a/mcp-servers/texas-longhorns/index.js
+++ b/mcp-servers/texas-longhorns/index.js
@@ -1,0 +1,1069 @@
+#!/usr/bin/env node
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { parse } from 'csv-parse/sync';
+
+const FOOTBALL_ROSTER_BASE = 'https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/rosters/csv';
+const FOOTBALL_SCHEDULE_BASE = 'https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/schedules/csv';
+const BASEBALL_ROSTER_URL = 'https://raw.githubusercontent.com/nathanblumenfeld/collegebaseball/main/collegebaseball/data/rosters_2012_2023_all.csv';
+const BASEBALL_GAMES_URL = 'https://raw.githubusercontent.com/nathanblumenfeld/collegebaseball/main/collegebaseball/data/games_1992_2021.csv';
+const GITHUB_SEARCH_ISSUES = 'https://api.github.com/search/issues';
+
+const CLASS_TRANSLATIONS = {
+  '1': 'FR',
+  '2': 'SO',
+  '3': 'JR',
+  '4': 'SR',
+  '5': 'GR',
+  'FR': 'FR',
+  'RFR': 'RFR',
+  'RSFR': 'RFR',
+  'SO': 'SO',
+  'RSO': 'RSO',
+  'JR': 'JR',
+  'RSJR': 'RSJR',
+  'SR': 'SR',
+  'RSSR': 'RSSR',
+  'GR': 'GR',
+};
+
+const POSITION_SIDES = {
+  QB: 'Offense',
+  RB: 'Offense',
+  TB: 'Offense',
+  HB: 'Offense',
+  FB: 'Offense',
+  WR: 'Offense',
+  TE: 'Offense',
+  OL: 'Offense',
+  OT: 'Offense',
+  OG: 'Offense',
+  C: 'Offense',
+  DL: 'Defense',
+  DE: 'Defense',
+  DT: 'Defense',
+  NT: 'Defense',
+  LB: 'Defense',
+  ILB: 'Defense',
+  OLB: 'Defense',
+  DB: 'Defense',
+  CB: 'Defense',
+  S: 'Defense',
+  FS: 'Defense',
+  SS: 'Defense',
+  STAR: 'Defense',
+  NICKEL: 'Defense',
+  PK: 'Special Teams',
+  P: 'Special Teams',
+  LS: 'Special Teams',
+  K: 'Special Teams',
+  KR: 'Special Teams',
+  PR: 'Special Teams',
+};
+
+const DEFAULT_CACHE_TTL = 1000 * 60 * 15; // 15 minutes
+
+function toNumber(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  const trimmed = String(value).trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toBoolean(value) {
+  if (typeof value === 'boolean') return value;
+  if (value === null || value === undefined) return false;
+  const normalized = String(value).trim().toLowerCase();
+  return normalized === 'true' || normalized === 't' || normalized === '1' || normalized === 'yes';
+}
+
+function parseHeightToInches(rawHeight) {
+  const numeric = toNumber(rawHeight);
+  if (numeric) return numeric;
+  if (!rawHeight) return null;
+  const text = String(rawHeight).trim();
+  const match = text.match(/(\d+)[\-'](\d{1,2})/);
+  if (match) {
+    const feet = Number(match[1]);
+    const inches = Number(match[2]);
+    return feet * 12 + inches;
+  }
+  return null;
+}
+
+function formatHeight(inches) {
+  const total = toNumber(inches);
+  if (!total) return null;
+  const feet = Math.floor(total / 12);
+  const remainder = total % 12;
+  return `${feet}'${remainder}\"`;
+}
+
+function computeDepthScore(player) {
+  const classWeightMap = {
+    FR: 1,
+    RFR: 1.1,
+    SO: 1.8,
+    RSO: 2,
+    JR: 2.6,
+    RSJR: 2.8,
+    SR: 3.2,
+    RSSR: 3.4,
+    GR: 3.8,
+  };
+  const classLabel = player.classification || 'FR';
+  const classScore = classWeightMap[classLabel] ?? 1;
+  const weightScore = player.weight_lbs ? Math.min(player.weight_lbs / 100, 3) : 1;
+  const heightScore = player.height_inches ? Math.min(player.height_inches / 40, 3) : 1;
+  const experienceBoost = player.experience ?? 0;
+  return Number((classScore * 10 + weightScore + heightScore + experienceBoost).toFixed(3));
+}
+
+function attachRosterMetadata(player) {
+  const heightInches = parseHeightToInches(player.height);
+  const weightLbs = toNumber(player.weight);
+  const classLabel = CLASS_TRANSLATIONS[player.year?.toUpperCase?.() ?? player.year] || CLASS_TRANSLATIONS[String(player.year || '').toUpperCase()] || null;
+  const experience = classLabel
+    ? ['FR', 'RFR'].includes(classLabel)
+      ? 0
+      : ['SO', 'RSO'].includes(classLabel)
+      ? 1
+      : ['JR', 'RSJR'].includes(classLabel)
+      ? 2
+      : ['SR', 'RSSR'].includes(classLabel)
+      ? 3
+      : 4
+    : 0;
+  const bmi = heightInches && weightLbs ? Number(((weightLbs / (heightInches * heightInches)) * 703).toFixed(2)) : null;
+  const heightFormatted = formatHeight(heightInches);
+  const enriched = {
+    ...player,
+    height_inches: heightInches,
+    height_formatted: heightFormatted,
+    weight_lbs: weightLbs,
+    bmi,
+    classification: classLabel,
+    experience,
+  };
+  enriched.depth_score = computeDepthScore(enriched);
+  return enriched;
+}
+
+function normalizeName(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function summarizeSchedule(games) {
+  const summary = {
+    record: { wins: 0, losses: 0, ties: 0 },
+    conferenceRecord: { wins: 0, losses: 0, ties: 0 },
+    pointsFor: 0,
+    pointsAgainst: 0,
+    averageMargin: null,
+    completedGames: [],
+    upcomingGames: [],
+    streak: null,
+    lastFive: [],
+    notableWins: [],
+    closeLosses: [],
+  };
+
+  const resultsSequence = [];
+  for (const game of games) {
+    const { result, conferenceGame } = game;
+    if (result.status === 'scheduled') {
+      summary.upcomingGames.push(game);
+      continue;
+    }
+
+    summary.completedGames.push(game);
+    if (typeof result.margin === 'number') {
+      summary.pointsFor += result.texasPoints ?? 0;
+      summary.pointsAgainst += result.opponentPoints ?? 0;
+    }
+
+    if (result.outcome === 'W') {
+      summary.record.wins += 1;
+      if (conferenceGame) summary.conferenceRecord.wins += 1;
+      if (typeof result.margin === 'number' && result.margin >= 14) {
+        summary.notableWins.push(game);
+      }
+      resultsSequence.push('W');
+    } else if (result.outcome === 'L') {
+      summary.record.losses += 1;
+      if (conferenceGame) summary.conferenceRecord.losses += 1;
+      if (typeof result.margin === 'number' && Math.abs(result.margin) <= 7) {
+        summary.closeLosses.push(game);
+      }
+      resultsSequence.push('L');
+    } else {
+      summary.record.ties += 1;
+      if (conferenceGame) summary.conferenceRecord.ties += 1;
+      resultsSequence.push('T');
+    }
+  }
+
+  if (summary.completedGames.length > 0) {
+    summary.averageMargin = Number(
+      (
+        (summary.pointsFor - summary.pointsAgainst) /
+        summary.completedGames.length
+      ).toFixed(2)
+    );
+  }
+
+  if (resultsSequence.length > 0) {
+    let streakType = resultsSequence.at(-1);
+    let streakLength = 0;
+    for (let i = resultsSequence.length - 1; i >= 0; i -= 1) {
+      if (resultsSequence[i] === streakType) {
+        streakLength += 1;
+      } else {
+        break;
+      }
+    }
+    summary.streak = `${streakType}${streakLength}`;
+    summary.lastFive = resultsSequence.slice(-5);
+  }
+
+  return summary;
+}
+
+function summarizeBaseballResults(games) {
+  const summary = {
+    record: { wins: 0, losses: 0, ties: 0 },
+    runsScored: 0,
+    runsAllowed: 0,
+    averageMargin: null,
+    bestWin: null,
+    toughestLoss: null,
+  };
+
+  for (const game of games) {
+    if (typeof game.runDifference !== 'number') continue;
+    summary.runsScored += game.runsScored ?? 0;
+    summary.runsAllowed += game.runsAllowed ?? 0;
+    if (game.runDifference > 0) {
+      summary.record.wins += 1;
+      if (!summary.bestWin || game.runDifference > summary.bestWin.runDifference) {
+        summary.bestWin = game;
+      }
+    } else if (game.runDifference < 0) {
+      summary.record.losses += 1;
+      if (!summary.toughestLoss || game.runDifference < summary.toughestLoss.runDifference) {
+        summary.toughestLoss = game;
+      }
+    } else {
+      summary.record.ties += 1;
+    }
+  }
+
+  if (games.length > 0) {
+    summary.averageMargin = Number(
+      (
+        (summary.runsScored - summary.runsAllowed) /
+        games.length
+      ).toFixed(2)
+    );
+  }
+
+  return summary;
+}
+
+function baseballGameFromRow(row) {
+  const runsScored = toNumber(row.runs_scored);
+  const runsAllowed = toNumber(row.runs_allowed);
+  const margin =
+    typeof runsScored === 'number' && typeof runsAllowed === 'number'
+      ? runsScored - runsAllowed
+      : null;
+  return {
+    date: row.date,
+    venueType: row.field,
+    opponent: row.opponent,
+    runsScored,
+    runsAllowed,
+    runDifference: margin,
+    outcome: margin > 0 ? 'W' : margin < 0 ? 'L' : 'T',
+    season: Number(row.season) || null,
+    school: row.school,
+  };
+}
+
+function formatFootballGame(row) {
+  const homeTeam = row.home_team;
+  const awayTeam = row.away_team;
+  const homePoints = toNumber(row.home_points);
+  const awayPoints = toNumber(row.away_points);
+  const completed = toBoolean(row.completed);
+  const isHome = homeTeam === 'Texas';
+  const opponent = isHome ? awayTeam : homeTeam;
+  const texasPoints = isHome ? homePoints : awayPoints;
+  const opponentPoints = isHome ? awayPoints : homePoints;
+  let outcome = 'scheduled';
+  let margin = null;
+  if (completed && texasPoints !== null && opponentPoints !== null) {
+    margin = texasPoints - opponentPoints;
+    if (margin > 0) outcome = 'W';
+    else if (margin < 0) outcome = 'L';
+    else outcome = 'T';
+  }
+
+  return {
+    gameId: row.game_id,
+    season: Number(row.season) || null,
+    week: Number(row.week) || null,
+    seasonType: row.season_type,
+    date: row.start_date,
+    venue: row.venue,
+    location: row.neutral_site === 'TRUE' ? 'neutral' : isHome ? 'home' : 'away',
+    opponent,
+    conferenceGame: row.conference_game === 'TRUE',
+    attendance: toNumber(row.attendance),
+    excitementIndex: toNumber(row.excitement_index),
+    notes: row.notes || null,
+    result: {
+      status: completed ? 'completed' : 'scheduled',
+      outcome,
+      texasPoints,
+      opponentPoints,
+      margin,
+    },
+  };
+}
+
+class LonghornsDataService {
+  constructor() {
+    this.cache = new Map();
+  }
+
+  getCached(key) {
+    const entry = this.cache.get(key);
+    if (!entry) return null;
+    if (entry.expires && entry.expires < Date.now()) {
+      this.cache.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  setCached(key, value, ttl = DEFAULT_CACHE_TTL) {
+    this.cache.set(key, {
+      value,
+      expires: ttl ? Date.now() + ttl : null,
+    });
+    return value;
+  }
+
+  async fetchText(url, { ttl = DEFAULT_CACHE_TTL, headers = {} } = {}) {
+    const cached = this.getCached(url);
+    if (cached) return cached;
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'texas-longhorns-mcp-server',
+        ...headers,
+      },
+    });
+    if (!response.ok) {
+      const details = await response.text().catch(() => '');
+      throw new Error(`Request failed for ${url}: ${response.status} ${details}`);
+    }
+    const text = await response.text();
+    this.setCached(url, text, ttl);
+    return text;
+  }
+
+  async fetchCSV(url, options = {}) {
+    const cacheKey = `csv:${url}`;
+    const cached = this.getCached(cacheKey);
+    if (cached) return cached;
+    const text = await this.fetchText(url, options);
+    const rows = parse(text, {
+      columns: true,
+      skip_empty_lines: true,
+    });
+    return this.setCached(cacheKey, rows, options.ttl ?? DEFAULT_CACHE_TTL);
+  }
+
+  async getFootballRoster(season) {
+    const resolvedSeason = season ?? new Date().getFullYear();
+    const possibleSeasons = [resolvedSeason, resolvedSeason - 1, resolvedSeason - 2];
+    let rosterRows = null;
+    let usedSeason = null;
+    for (const yr of possibleSeasons) {
+      const url = `${FOOTBALL_ROSTER_BASE}/cfb_rosters_${yr}.csv`;
+      try {
+        const rows = await this.fetchCSV(url, { ttl: 1000 * 60 * 60 });
+        rosterRows = rows.filter((row) => row.team === 'Texas');
+        if (rosterRows.length > 0) {
+          usedSeason = yr;
+          break;
+        }
+      } catch (error) {
+        continue;
+      }
+    }
+    if (!rosterRows || rosterRows.length === 0) {
+      throw new Error('Unable to locate Texas roster data for the requested range.');
+    }
+
+    const enriched = rosterRows.map((row) =>
+      attachRosterMetadata({
+        athlete_id: row.athlete_id,
+        first_name: row.first_name,
+        last_name: row.last_name,
+        position: row.position,
+        height: row.height,
+        weight: row.weight,
+        jersey: row.jersey,
+        year: row.year,
+        home_city: row.home_city,
+        home_state: row.home_state,
+        home_country: row.home_country,
+        headshot_url: row.headshot_url,
+        hometown: [row.home_city, row.home_state, row.home_country].filter(Boolean).join(', '),
+      })
+    );
+
+    return {
+      season: usedSeason,
+      count: enriched.length,
+      players: enriched,
+      source: `${FOOTBALL_ROSTER_BASE}/cfb_rosters_${usedSeason}.csv`,
+    };
+  }
+
+  async getFootballDepthChart(season) {
+    const rosterData = await this.getFootballRoster(season);
+    const depthChart = {};
+    for (const player of rosterData.players) {
+      const position = player.position || 'ATH';
+      if (!depthChart[position]) depthChart[position] = [];
+      depthChart[position].push(player);
+    }
+
+    for (const position of Object.keys(depthChart)) {
+      depthChart[position].sort((a, b) => b.depth_score - a.depth_score);
+    }
+
+    const positionGroups = {};
+    for (const [position, players] of Object.entries(depthChart)) {
+      const side = POSITION_SIDES[position] || 'Special Teams';
+      if (!positionGroups[side]) positionGroups[side] = {};
+      positionGroups[side][position] = players.slice(0, 5).map((player, index) => ({
+        rank: index + 1,
+        athlete_id: player.athlete_id,
+        name: `${player.first_name} ${player.last_name}`.trim(),
+        position: player.position,
+        classification: player.classification,
+        height: player.height_formatted,
+        weight: player.weight_lbs,
+        depth_score: player.depth_score,
+      }));
+    }
+
+    return {
+      season: rosterData.season,
+      positionGroups,
+      source: rosterData.source,
+    };
+  }
+
+  async fetchFootballSeasonRows(season) {
+    const url = `${FOOTBALL_SCHEDULE_BASE}/cfb_schedules_${season}.csv`;
+    return this.fetchCSV(url, { ttl: 1000 * 60 * 60 });
+  }
+
+  async getFootballSeasonSchedule(season) {
+    const resolvedSeason = season ?? new Date().getFullYear();
+    const rows = await this.fetchFootballSeasonRows(resolvedSeason);
+    const texasGames = rows.filter(
+      (row) => row.home_team === 'Texas' || row.away_team === 'Texas'
+    );
+    const games = texasGames.map(formatFootballGame);
+    const summary = summarizeSchedule(games);
+    return {
+      season: resolvedSeason,
+      games,
+      summary,
+      source: `${FOOTBALL_SCHEDULE_BASE}/cfb_schedules_${resolvedSeason}.csv`,
+    };
+  }
+
+  async getFootballSeasonStats(season) {
+    const schedule = await this.getFootballSeasonSchedule(season);
+    const games = schedule.games;
+    const completed = games.filter((game) => game.result.status === 'completed');
+    const totalGames = completed.length;
+    const pointsFor = completed.reduce((sum, game) => sum + (game.result.texasPoints ?? 0), 0);
+    const pointsAgainst = completed.reduce(
+      (sum, game) => sum + (game.result.opponentPoints ?? 0),
+      0
+    );
+
+    const homeGames = completed.filter((game) => game.location === 'home');
+    const roadGames = completed.filter((game) => game.location === 'away');
+    const neutralGames = completed.filter((game) => game.location === 'neutral');
+
+    const countOutcome = (gamesArr, outcome) =>
+      gamesArr.filter((game) => game.result.outcome === outcome).length;
+
+    const stats = {
+      season: schedule.season,
+      gamesPlayed: totalGames,
+      pointsFor,
+      pointsAgainst,
+      averagePointsFor: totalGames ? Number((pointsFor / totalGames).toFixed(2)) : null,
+      averagePointsAgainst: totalGames ? Number((pointsAgainst / totalGames).toFixed(2)) : null,
+      averageMargin: totalGames
+        ? Number(((pointsFor - pointsAgainst) / totalGames).toFixed(2))
+        : null,
+      homeRecord: {
+        wins: countOutcome(homeGames, 'W'),
+        losses: countOutcome(homeGames, 'L'),
+        ties: countOutcome(homeGames, 'T'),
+      },
+      roadRecord: {
+        wins: countOutcome(roadGames, 'W'),
+        losses: countOutcome(roadGames, 'L'),
+        ties: countOutcome(roadGames, 'T'),
+      },
+      neutralRecord: {
+        wins: countOutcome(neutralGames, 'W'),
+        losses: countOutcome(neutralGames, 'L'),
+        ties: countOutcome(neutralGames, 'T'),
+      },
+      closeGameRecord: {
+        wins: completed.filter((g) => Math.abs(g.result.margin ?? 0) <= 7 && g.result.outcome === 'W').length,
+        losses: completed.filter((g) => Math.abs(g.result.margin ?? 0) <= 7 && g.result.outcome === 'L').length,
+      },
+      blowoutWins: completed.filter((g) => (g.result.margin ?? 0) >= 21).length,
+      blowoutLosses: completed.filter((g) => (g.result.margin ?? 0) <= -21).length,
+      lastFive: completed.slice(-5),
+      summary: schedule.summary,
+      source: schedule.source,
+    };
+
+    return stats;
+  }
+
+  async getFootballMatchupHistory(opponent, { startSeason = 1997, endSeason = new Date().getFullYear() } = {}) {
+    if (!opponent) throw new Error('Opponent is required for matchup history.');
+    const normalizedOpponent = normalizeName(opponent);
+    const results = [];
+    for (let season = startSeason; season <= endSeason; season += 1) {
+      try {
+        const rows = await this.fetchFootballSeasonRows(season);
+        for (const row of rows) {
+          if (row.home_team !== 'Texas' && row.away_team !== 'Texas') continue;
+          const opponentName = row.home_team === 'Texas' ? row.away_team : row.home_team;
+          if (normalizeName(opponentName) !== normalizedOpponent) continue;
+          const game = formatFootballGame(row);
+          results.push(game);
+        }
+      } catch (error) {
+        continue;
+      }
+    }
+
+    if (results.length === 0) {
+      return {
+        opponent,
+        startSeason,
+        endSeason,
+        meetings: [],
+        record: { wins: 0, losses: 0, ties: 0 },
+        averageMargin: null,
+        largestWin: null,
+        toughestLoss: null,
+      };
+    }
+
+    let wins = 0;
+    let losses = 0;
+    let ties = 0;
+    let marginSum = 0;
+    let countedGames = 0;
+    let largestWin = null;
+    let toughestLoss = null;
+
+    for (const game of results) {
+      if (game.result.margin !== null) {
+        marginSum += game.result.margin;
+        countedGames += 1;
+        if (game.result.margin > 0) {
+          wins += 1;
+          if (!largestWin || game.result.margin > largestWin.result.margin) {
+            largestWin = game;
+          }
+        } else if (game.result.margin < 0) {
+          losses += 1;
+          if (!toughestLoss || game.result.margin < toughestLoss.result.margin) {
+            toughestLoss = game;
+          }
+        } else {
+          ties += 1;
+        }
+      }
+    }
+
+    const averageMargin = countedGames ? Number((marginSum / countedGames).toFixed(2)) : null;
+
+    return {
+      opponent,
+      startSeason,
+      endSeason,
+      meetings: results.sort((a, b) => (a.date || '').localeCompare(b.date || '')),
+      record: { wins, losses, ties },
+      averageMargin,
+      largestWin,
+      toughestLoss,
+      lastMeeting: results.at(-1),
+    };
+  }
+
+  async getBaseballRoster(season = 2023) {
+    const rows = await this.fetchCSV(BASEBALL_ROSTER_URL, { ttl: 1000 * 60 * 60 });
+    const filtered = rows.filter(
+      (row) => row.school === 'Texas' && (!season || Number(row.season) === Number(season))
+    );
+    const players = filtered.map((row) => ({
+      jersey: row.jersey,
+      name: row.name,
+      position: row.position,
+      height: row.height || null,
+      class_year: row.class_year || null,
+      games_played: toNumber(row.games_played),
+      games_started: toNumber(row.games_started),
+      season: Number(row.season) || null,
+    }));
+    return {
+      season: season ?? null,
+      count: players.length,
+      players,
+      source: BASEBALL_ROSTER_URL,
+    };
+  }
+
+  async getBaseballSeasonResults(season) {
+    const rows = await this.fetchCSV(BASEBALL_GAMES_URL, { ttl: 1000 * 60 * 60 });
+    const filtered = rows.filter(
+      (row) => row.school === 'Texas' && (!season || Number(row.season) === Number(season))
+    );
+    const games = filtered.map(baseballGameFromRow);
+    const summary = summarizeBaseballResults(games);
+    return {
+      season: season ?? null,
+      games,
+      summary,
+      source: BASEBALL_GAMES_URL,
+    };
+  }
+
+  async getBaseballMatchupHistory(opponent, { startSeason = 1992, endSeason = 2021 } = {}) {
+    if (!opponent) throw new Error('Opponent is required for baseball matchup history.');
+    const normalizedOpponent = normalizeName(opponent);
+    const rows = await this.fetchCSV(BASEBALL_GAMES_URL, { ttl: 1000 * 60 * 60 });
+    const games = rows
+      .filter((row) => row.school === 'Texas')
+      .filter((row) => normalizeName(row.opponent) === normalizedOpponent)
+      .filter((row) => {
+        const season = Number(row.season);
+        return season >= startSeason && season <= endSeason;
+      })
+      .map(baseballGameFromRow);
+
+    if (games.length === 0) {
+      return {
+        opponent,
+        startSeason,
+        endSeason,
+        meetings: [],
+        record: { wins: 0, losses: 0, ties: 0 },
+        averageMargin: null,
+        bestWin: null,
+        toughestLoss: null,
+      };
+    }
+
+    const summary = summarizeBaseballResults(games);
+    return {
+      opponent,
+      startSeason,
+      endSeason,
+      meetings: games,
+      record: summary.record,
+      averageMargin: summary.averageMargin,
+      bestWin: summary.bestWin,
+      toughestLoss: summary.toughestLoss,
+    };
+  }
+
+  async getLonghornsNews({ query = 'Texas Longhorns', days = 14, limit = 12 } = {}) {
+    const sinceDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    const q = `${query} created:>=${sinceDate}`;
+    const url = `${GITHUB_SEARCH_ISSUES}?q=${encodeURIComponent(q)}&sort=created&order=desc&per_page=${Math.min(
+      limit,
+      30
+    )}`;
+    const text = await this.fetchText(url, {
+      ttl: 1000 * 60 * 10,
+      headers: { Accept: 'application/vnd.github+json' },
+    });
+    const payload = JSON.parse(text);
+    const items = (payload.items || []).map((item) => ({
+      title: item.title,
+      url: item.html_url,
+      created_at: item.created_at,
+      updated_at: item.updated_at,
+      comments: item.comments,
+      repository: item.repository_url?.split('/').slice(-2).join('/') ?? null,
+      snippet: item.body ? item.body.slice(0, 280) : null,
+      type: item.pull_request ? 'pull_request' : item.html_url.includes('/discussions/') ? 'discussion' : 'issue',
+    }));
+    return {
+      query,
+      since: sinceDate,
+      totalCount: payload.total_count,
+      items,
+      source: url,
+    };
+  }
+}
+
+class TexasLonghornsServer {
+  constructor() {
+    this.dataService = new LonghornsDataService();
+    this.server = new Server(
+      {
+        name: 'texas-longhorns',
+        version: '1.0.0',
+      },
+      {
+        capabilities: {
+          tools: {},
+        },
+      }
+    );
+    this.setupHandlers();
+  }
+
+  setupHandlers() {
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: [
+        {
+          name: 'getFootballRoster',
+          description:
+            'Fetch the Texas Longhorns football roster with height/weight metadata for a given season.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              season: {
+                type: 'integer',
+                description: 'Season year (e.g., 2025). Defaults to the current year.',
+              },
+            },
+          },
+        },
+        {
+          name: 'getFootballDepthChart',
+          description: 'Builds a depth chart from the roster with ranking heuristics.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              season: { type: 'integer', description: 'Season year for the depth chart.' },
+            },
+          },
+        },
+        {
+          name: 'getFootballSeasonSchedule',
+          description: 'Retrieve the full season schedule, completed results, and upcoming games.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              season: { type: 'integer', description: 'Season year (e.g., 2025).' },
+            },
+          },
+        },
+        {
+          name: 'getFootballSeasonStats',
+          description:
+            'Compute aggregate performance metrics (points, margins, situational records) for a season.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              season: { type: 'integer', description: 'Season year (e.g., 2024).' },
+            },
+          },
+        },
+        {
+          name: 'getFootballMatchupHistory',
+          description: 'Summarize the Longhorns historical record against a specific opponent.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              opponent: {
+                type: 'string',
+                description: 'Opponent name (e.g., Alabama).',
+              },
+              startSeason: {
+                type: 'integer',
+                description: 'Earliest season to include (default 1997).',
+              },
+              endSeason: {
+                type: 'integer',
+                description: 'Latest season to include (default current year).',
+              },
+            },
+            required: ['opponent'],
+          },
+        },
+        {
+          name: 'getBaseballRoster',
+          description: 'Retrieve the Texas baseball roster from the historical dataset (2012-2023).',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              season: {
+                type: 'integer',
+                description: 'Season year between 2012 and 2023.',
+              },
+            },
+          },
+        },
+        {
+          name: 'getBaseballSeasonResults',
+          description: 'Retrieve season results for Texas baseball (1992-2021 data coverage).',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              season: {
+                type: 'integer',
+                description: 'Season year (1992-2021) to summarize.',
+              },
+            },
+          },
+        },
+        {
+          name: 'getBaseballMatchupHistory',
+          description: 'Summarize baseball matchup history against a specific opponent.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              opponent: { type: 'string', description: 'Opponent name.' },
+              startSeason: {
+                type: 'integer',
+                description: 'Earliest season to include (default 1992).',
+              },
+              endSeason: {
+                type: 'integer',
+                description: 'Latest season to include (default 2021).',
+              },
+            },
+            required: ['opponent'],
+          },
+        },
+        {
+          name: 'getLonghornsNews',
+          description:
+            'Fetch recent GitHub discussions/issues mentioning the Longhorns to monitor news and chatter.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              query: {
+                type: 'string',
+                description: 'Custom search phrase (default "Texas Longhorns").',
+              },
+              days: {
+                type: 'integer',
+                description: 'Lookback window in days (default 14).',
+              },
+              limit: {
+                type: 'integer',
+                description: 'Maximum number of items to return (default 12).',
+              },
+            },
+          },
+        },
+      ],
+    }));
+
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: args = {} } = request.params;
+      try {
+        switch (name) {
+          case 'getFootballRoster':
+            return this.handleGetFootballRoster(args);
+          case 'getFootballDepthChart':
+            return this.handleGetFootballDepthChart(args);
+          case 'getFootballSeasonSchedule':
+            return this.handleGetFootballSeasonSchedule(args);
+          case 'getFootballSeasonStats':
+            return this.handleGetFootballSeasonStats(args);
+          case 'getFootballMatchupHistory':
+            return this.handleGetFootballMatchupHistory(args);
+          case 'getBaseballRoster':
+            return this.handleGetBaseballRoster(args);
+          case 'getBaseballSeasonResults':
+            return this.handleGetBaseballSeasonResults(args);
+          case 'getBaseballMatchupHistory':
+            return this.handleGetBaseballMatchupHistory(args);
+          case 'getLonghornsNews':
+            return this.handleGetLonghornsNews(args);
+          default:
+            throw new Error(`Unknown tool: ${name}`);
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error executing ${name}: ${error.message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    });
+  }
+
+  async handleGetFootballRoster(args) {
+    const data = await this.dataService.getFootballRoster(args.season);
+    return {
+      content: [
+        {
+          type: 'json',
+          json: data,
+        },
+      ],
+    };
+  }
+
+  async handleGetFootballDepthChart(args) {
+    const data = await this.dataService.getFootballDepthChart(args.season);
+    return {
+      content: [
+        {
+          type: 'json',
+          json: data,
+        },
+      ],
+    };
+  }
+
+  async handleGetFootballSeasonSchedule(args) {
+    const data = await this.dataService.getFootballSeasonSchedule(args.season);
+    return {
+      content: [
+        {
+          type: 'json',
+          json: data,
+        },
+      ],
+    };
+  }
+
+  async handleGetFootballSeasonStats(args) {
+    const data = await this.dataService.getFootballSeasonStats(args.season);
+    return {
+      content: [
+        {
+          type: 'json',
+          json: data,
+        },
+      ],
+    };
+  }
+
+  async handleGetFootballMatchupHistory(args) {
+    const data = await this.dataService.getFootballMatchupHistory(args.opponent, {
+      startSeason: args.startSeason,
+      endSeason: args.endSeason,
+    });
+    return {
+      content: [
+        {
+          type: 'json',
+          json: data,
+        },
+      ],
+    };
+  }
+
+  async handleGetBaseballRoster(args) {
+    const data = await this.dataService.getBaseballRoster(args.season);
+    return {
+      content: [
+        {
+          type: 'json',
+          json: data,
+        },
+      ],
+    };
+  }
+
+  async handleGetBaseballSeasonResults(args) {
+    const data = await this.dataService.getBaseballSeasonResults(args.season);
+    return {
+      content: [
+        {
+          type: 'json',
+          json: data,
+        },
+      ],
+    };
+  }
+
+  async handleGetBaseballMatchupHistory(args) {
+    const data = await this.dataService.getBaseballMatchupHistory(args.opponent, {
+      startSeason: args.startSeason,
+      endSeason: args.endSeason,
+    });
+    return {
+      content: [
+        {
+          type: 'json',
+          json: data,
+        },
+      ],
+    };
+  }
+
+  async handleGetLonghornsNews(args) {
+    const data = await this.dataService.getLonghornsNews({
+      query: args.query,
+      days: args.days,
+      limit: args.limit,
+    });
+    return {
+      content: [
+        {
+          type: 'json',
+          json: data,
+        },
+      ],
+    };
+  }
+
+  async run() {
+    const transport = new StdioServerTransport();
+    await this.server.connect(transport);
+    console.error('Texas Longhorns MCP server listening on stdio');
+  }
+}
+
+const server = new TexasLonghornsServer();
+server.run().catch((error) => {
+  console.error('Failed to start Texas Longhorns MCP server:', error);
+  process.exit(1);
+});
+

--- a/mcp-servers/texas-longhorns/package-lock.json
+++ b/mcp-servers/texas-longhorns/package-lock.json
@@ -1,0 +1,1105 @@
+{
+  "name": "texas-longhorns-mcp-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "texas-longhorns-mcp-server",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.18.1",
+        "csv-parse": "^6.1.0",
+        "fast-xml-parser": "^5.2.5"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.18.1.tgz",
+      "integrity": "sha512-d//GE8/Yh7aC3e7p+kZG8JqqEAwwDUmAfvH1quogtbk+ksS6E0RR6toKKESPYYZVre0meqkJb27zb+dhqE9Sgw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csv-parse": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.1.0.tgz",
+      "integrity": "sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.7.0",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
+      }
+    }
+  }
+}

--- a/mcp-servers/texas-longhorns/package.json
+++ b/mcp-servers/texas-longhorns/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "texas-longhorns-mcp-server",
+  "version": "1.0.0",
+  "description": "MCP server providing Texas Longhorns football and baseball data integrations",
+  "type": "module",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.18.1",
+    "csv-parse": "^6.1.0",
+    "fast-xml-parser": "^5.2.5"
+  }
+}


### PR DESCRIPTION
## Summary
- implement a dedicated Texas Longhorns MCP server that serves football rosters, depth charts, schedules, matchup history, and season stats alongside baseball data and news aggregation
- add package metadata and dependencies required for the new server module

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68cc4124a0788330b3c9b88769a8e064