### PR TITLE
Add Longhorns dataset and Netlify API

### DIFF
--- a/05_DOCS/technical/blaze-api-documentation.md
+++ b/05_DOCS/technical/blaze-api-documentation.md
@@ -163,6 +163,57 @@ Returns full roster with HAV-F scores for all players on a team.
 }
 ```
 
+#### GET `/api/longhorns`
+Provides Blaze Intelligence with program-specific datasets for the Texas Longhorns. The route is powered by the Netlify function `netlify/functions/longhorns.js` and serves curated season bundles for football and baseball.
+
+**Query Parameters**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `sport` | `string` | `football` | Supported values: `football`, `baseball`. |
+| `season` | `number` | Latest available | Optional season override. The repository currently includes 2023 data while 2024/2025 ingestion is pending. |
+| `category` | `string` | _none_ | Optional filter returning a single section (`summary`, `schedule`, `keyPlayers`, `updatePlan`, etc.). |
+
+**Example – football schedule**
+
+```bash
+curl "https://blaze-intelligence.netlify.app/api/longhorns?sport=football&category=schedule"
+```
+
+**Response**
+
+```json
+{
+  "sport": "football",
+  "season": 2023,
+  "availableSeasons": [2023],
+  "dataStatus": "historical",
+  "lastUpdated": "2024-01-02T00:00:00Z",
+  "requestedCategory": "schedule",
+  "data": [
+    {
+      "date": "2023-09-02",
+      "opponent": "Rice",
+      "gameType": "Regular Season",
+      "result": "W",
+      "score": { "texas": 37, "opponent": 10 }
+    }
+  ],
+  "metadata": {
+    "summaryAvailable": true,
+    "scheduleAvailable": true,
+    "keyPlayersAvailable": true,
+    "updatePlanIncluded": true
+  }
+}
+```
+
+**Notes**
+
+- Football coverage reflects the 12-2 2023 season (Big 12 title, CFP semifinal appearance). Values are derived from publicly available box scores and should be replaced by licensed feeds before production launch.
+- Baseball coverage summarises the 42-22 2023 campaign (Austin Regional champions, Stanford Super Regional appearance).
+- The `updatePlan` field highlights ingestion tasks (e.g., onboarding 2024/2025 data, automating roster scrapes, wiring news feeds). Surfacing those tasks in internal dashboards will keep stakeholders aware of remaining work.
+
 ---
 
 ### Readiness Data

--- a/data/longhorns/baseball-2023.json
+++ b/data/longhorns/baseball-2023.json
@@ -1,0 +1,61 @@
+{
+  "meta": {
+    "season": 2023,
+    "program": "Texas Longhorns",
+    "sport": "baseball",
+    "lastUpdated": "2023-06-12T00:00:00Z",
+    "dataStatus": "historical",
+    "sources": [
+      "University of Texas 2023 baseball media guide and postseason recaps",
+      "NCAA regional and super regional box scores"
+    ],
+    "notes": "Summary data describing Texas' 2023 campaign. Detailed pitch-by-pitch statistics should be ingested from a licensed provider such as D1Baseball before rolling out production endpoints."
+  },
+  "summary": {
+    "overallRecord": "42-22",
+    "conferenceRecord": "15-9",
+    "conference": "Big 12",
+    "regularSeasonTitle": "Co-champions",
+    "postseason": {
+      "big12Tournament": "Eliminated in Saturday bracket play",
+      "ncaaRegional": "Austin Regional champions (3-0)",
+      "ncaaSuperRegional": "Lost to Stanford 1-2 in Palo Alto"
+    },
+    "headCoach": "David Pierce",
+    "ballpark": "UFCU Disch-Falk Field"
+  },
+  "keyPlayers": {
+    "hitters": [
+      { "name": "Dylan Campbell", "position": "OF", "notes": "Program-record 38-game hitting streak; All-Big 12 first team." },
+      { "name": "Peyton Powell", "position": "3B", "notes": "Corner infielder who hit in the middle of the order all season." },
+      { "name": "Porter Brown", "position": "OF", "notes": "TCU transfer supplied left-handed power and clutch postseason at-bats." },
+      { "name": "Garrett Guillemette", "position": "C", "notes": "Southern California transfer who handled the pitching staff." },
+      { "name": "Eric Kennedy", "position": "OF", "notes": "Fifth-year senior spark plug with speed on the bases." }
+    ],
+    "pitchers": [
+      { "name": "Lucas Gordon", "throws": "LHP", "notes": "Friday-night starter and Big 12 Pitcher of the Year." },
+      { "name": "Lebarron Johnson Jr.", "throws": "RHP", "notes": "Power arm who starred in the Austin Regional." },
+      { "name": "Charlie Hurley", "throws": "RHP", "notes": "Transfer innings-eater who stabilized the rotation." },
+      { "name": "Andre Duplantier II", "throws": "RHP", "notes": "Multi-inning relief ace." },
+      { "name": "Zane Morehouse", "throws": "RHP", "notes": "Late-inning reliever deployed in high-leverage spots." }
+    ]
+  },
+  "notableSeries": [
+    { "opponent": "Texas Tech", "result": "Home sweep secured share of the Big 12 regular-season title" },
+    { "opponent": "West Virginia", "result": "Late-season sweep fueled title push" },
+    { "event": "Austin Regional", "result": "Defeated Louisiana, Miami (FL) twice to advance" },
+    { "event": "Stanford Super Regional", "result": "Won opener behind Lebarron Johnson Jr.; dropped the final two games" }
+  ],
+  "updatePlan": {
+    "priority": [
+      "Add per-game box scores and player stat splits using a licensed college baseball feed.",
+      "Track 2024 MLB Draft outcomes for departing players.",
+      "Load 2025 roster once official athletics release is published."
+    ],
+    "recommendedSources": [
+      "D1Baseball team statistics feed",
+      "TexasSports.com roster pages",
+      "Perfect Game scouting reports"
+    ]
+  }
+}

--- a/data/longhorns/football-2023.json
+++ b/data/longhorns/football-2023.json
@@ -1,0 +1,218 @@
+{
+  "meta": {
+    "season": 2023,
+    "program": "Texas Longhorns",
+    "sport": "football",
+    "lastUpdated": "2024-01-02T00:00:00Z",
+    "dataStatus": "historical",
+    "sources": [
+      "University of Texas 2023 football schedule and game results (public records)",
+      "College Football Playoff semifinal box score vs. Washington (January 1, 2024)"
+    ],
+    "notes": "Game-by-game scoring compiled to support the initial MCP API scaffolding. Update with official 2024 and 2025 statistics once available from licensed data providers."
+  },
+  "summary": {
+    "overallRecord": "12-2",
+    "conferenceRecord": "8-1",
+    "conference": "Big 12",
+    "finalRankingAP": 3,
+    "postseason": "Lost Sugar Bowl (CFP semifinal) to Washington 31-37",
+    "headCoach": "Steve Sarkisian",
+    "offensiveCoordinator": "Kyle Flood",
+    "defensiveCoordinator": "Pete Kwiatkowski"
+  },
+  "statistics": {
+    "gamesPlayed": 14,
+    "pointsFor": 501,
+    "pointsAgainst": 265,
+    "averagePointsFor": 35.79,
+    "averagePointsAgainst": 18.93,
+    "averageMargin": 16.86
+  },
+  "keyPlayers": {
+    "offense": [
+      { "name": "Quinn Ewers", "position": "QB", "notes": "Started 12 games and steered Texas to the College Football Playoff." },
+      { "name": "Jonathon Brooks", "position": "RB", "notes": "Team rushing leader prior to his November knee injury." },
+      { "name": "CJ Baxter Jr.", "position": "RB", "notes": "True freshman who closed the season as the primary ball carrier." },
+      { "name": "Xavier Worthy", "position": "WR", "notes": "All-Big 12 receiver and explosive punt returner." },
+      { "name": "Adonai Mitchell", "position": "WR", "notes": "Georgia transfer who supplied 11 touchdown receptions." },
+      { "name": "Ja'Tavion Sanders", "position": "TE", "notes": "Mismatch tight end and All-Big 12 selection." }
+    ],
+    "defense": [
+      { "name": "T'Vondre Sweat", "position": "DL", "notes": "Big 12 Defensive Player of the Year anchored the interior." },
+      { "name": "Byron Murphy II", "position": "DL", "notes": "Disruptive tackle who demanded double-teams." },
+      { "name": "Jaylan Ford", "position": "LB", "notes": "Team leader in tackles and veteran signal caller." },
+      { "name": "Anthony Hill Jr.", "position": "LB", "notes": "Freshman pass-rush specialist used in pressure packages." },
+      { "name": "Jahdae Barron", "position": "DB", "notes": "Nickel defender who produced multiple takeaways." },
+      { "name": "Jalen Catalon", "position": "DB", "notes": "Transfer safety who opened the season as a starter." }
+    ]
+  },
+  "schedule": [
+    {
+      "date": "2023-09-02",
+      "opponent": "Rice",
+      "location": "Austin, TX",
+      "venue": "Darrell K Royal–Texas Memorial Stadium",
+      "gameType": "Regular Season",
+      "conferenceGame": false,
+      "result": "W",
+      "score": { "texas": 37, "opponent": 10 },
+      "recordAfterGame": "1-0"
+    },
+    {
+      "date": "2023-09-09",
+      "opponent": "Alabama",
+      "location": "Tuscaloosa, AL",
+      "venue": "Bryant-Denny Stadium",
+      "gameType": "Regular Season",
+      "conferenceGame": false,
+      "result": "W",
+      "score": { "texas": 34, "opponent": 24 },
+      "recordAfterGame": "2-0"
+    },
+    {
+      "date": "2023-09-16",
+      "opponent": "Wyoming",
+      "location": "Austin, TX",
+      "venue": "Darrell K Royal–Texas Memorial Stadium",
+      "gameType": "Regular Season",
+      "conferenceGame": false,
+      "result": "W",
+      "score": { "texas": 31, "opponent": 10 },
+      "recordAfterGame": "3-0"
+    },
+    {
+      "date": "2023-09-23",
+      "opponent": "Baylor",
+      "location": "Waco, TX",
+      "venue": "McLane Stadium",
+      "gameType": "Regular Season",
+      "conferenceGame": true,
+      "result": "W",
+      "score": { "texas": 38, "opponent": 6 },
+      "recordAfterGame": "4-0"
+    },
+    {
+      "date": "2023-09-30",
+      "opponent": "Kansas",
+      "location": "Austin, TX",
+      "venue": "Darrell K Royal–Texas Memorial Stadium",
+      "gameType": "Regular Season",
+      "conferenceGame": true,
+      "result": "W",
+      "score": { "texas": 40, "opponent": 14 },
+      "recordAfterGame": "5-0"
+    },
+    {
+      "date": "2023-10-07",
+      "opponent": "Oklahoma",
+      "location": "Dallas, TX",
+      "venue": "Cotton Bowl",
+      "gameType": "Regular Season",
+      "conferenceGame": true,
+      "result": "L",
+      "score": { "texas": 30, "opponent": 34 },
+      "recordAfterGame": "5-1"
+    },
+    {
+      "date": "2023-10-21",
+      "opponent": "Houston",
+      "location": "Houston, TX",
+      "venue": "TDECU Stadium",
+      "gameType": "Regular Season",
+      "conferenceGame": true,
+      "result": "W",
+      "score": { "texas": 31, "opponent": 24 },
+      "recordAfterGame": "6-1"
+    },
+    {
+      "date": "2023-10-28",
+      "opponent": "BYU",
+      "location": "Austin, TX",
+      "venue": "Darrell K Royal–Texas Memorial Stadium",
+      "gameType": "Regular Season",
+      "conferenceGame": true,
+      "result": "W",
+      "score": { "texas": 35, "opponent": 6 },
+      "recordAfterGame": "7-1"
+    },
+    {
+      "date": "2023-11-04",
+      "opponent": "Kansas State",
+      "location": "Austin, TX",
+      "venue": "Darrell K Royal–Texas Memorial Stadium",
+      "gameType": "Regular Season",
+      "conferenceGame": true,
+      "result": "W",
+      "score": { "texas": 33, "opponent": 30 },
+      "recordAfterGame": "8-1"
+    },
+    {
+      "date": "2023-11-11",
+      "opponent": "TCU",
+      "location": "Fort Worth, TX",
+      "venue": "Amon G. Carter Stadium",
+      "gameType": "Regular Season",
+      "conferenceGame": true,
+      "result": "W",
+      "score": { "texas": 29, "opponent": 26 },
+      "recordAfterGame": "9-1"
+    },
+    {
+      "date": "2023-11-18",
+      "opponent": "Iowa State",
+      "location": "Ames, IA",
+      "venue": "Jack Trice Stadium",
+      "gameType": "Regular Season",
+      "conferenceGame": true,
+      "result": "W",
+      "score": { "texas": 26, "opponent": 16 },
+      "recordAfterGame": "10-1"
+    },
+    {
+      "date": "2023-11-24",
+      "opponent": "Texas Tech",
+      "location": "Austin, TX",
+      "venue": "Darrell K Royal–Texas Memorial Stadium",
+      "gameType": "Regular Season",
+      "conferenceGame": true,
+      "result": "W",
+      "score": { "texas": 57, "opponent": 7 },
+      "recordAfterGame": "11-1"
+    },
+    {
+      "date": "2023-12-02",
+      "opponent": "Oklahoma State",
+      "location": "Arlington, TX",
+      "venue": "AT&T Stadium",
+      "gameType": "Big 12 Championship",
+      "conferenceGame": true,
+      "result": "W",
+      "score": { "texas": 49, "opponent": 21 },
+      "recordAfterGame": "12-1"
+    },
+    {
+      "date": "2024-01-01",
+      "opponent": "Washington",
+      "location": "New Orleans, LA",
+      "venue": "Caesars Superdome",
+      "gameType": "Sugar Bowl (CFP semifinal)",
+      "conferenceGame": false,
+      "result": "L",
+      "score": { "texas": 31, "opponent": 37 },
+      "recordAfterGame": "12-2"
+    }
+  ],
+  "updatePlan": {
+    "priority": [
+      "Integrate 2024 season statistics once official NCAA data is released.",
+      "Automate roster and depth-chart ingestion using the CollegeFootballData API.",
+      "Map 2025 opponent schedules for matchup insight generation."
+    ],
+    "recommendedSources": [
+      "CollegeFootballData.com API",
+      "Official Texas Athletics releases",
+      "Ourlads depth charts"
+    ]
+  }
+}

--- a/netlify/functions/longhorns.js
+++ b/netlify/functions/longhorns.js
@@ -1,0 +1,139 @@
+const fs = require('fs');
+const path = require('path');
+
+const DATA_ROOT = path.join(__dirname, '..', '..', 'data', 'longhorns');
+
+const SPORT_INDEX = {
+  football: {
+    2023: 'football-2023.json'
+  },
+  baseball: {
+    2023: 'baseball-2023.json'
+  }
+};
+
+function listAvailableSeasons(sportKey) {
+  const seasonMap = SPORT_INDEX[sportKey];
+  if (!seasonMap) {
+    return [];
+  }
+  return Object.keys(seasonMap)
+    .map((season) => Number(season))
+    .filter((season) => Number.isFinite(season))
+    .sort((a, b) => a - b);
+}
+
+function resolveSeasonFile(sportKey, season) {
+  const seasonMap = SPORT_INDEX[sportKey];
+  if (!seasonMap) {
+    return null;
+  }
+  if (season && seasonMap[season]) {
+    return seasonMap[season];
+  }
+  const availableSeasons = listAvailableSeasons(sportKey);
+  if (availableSeasons.length === 0) {
+    return null;
+  }
+  const latestSeason = availableSeasons[availableSeasons.length - 1];
+  return seasonMap[String(latestSeason)];
+}
+
+function loadSeasonData(sportKey, season) {
+  const fileName = resolveSeasonFile(sportKey, season);
+  if (!fileName) {
+    return null;
+  }
+  const filePath = path.join(DATA_ROOT, fileName);
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed;
+  } catch (error) {
+    console.error(`Failed to read Longhorns data for ${sportKey} ${season || ''}:`, error);
+    return null;
+  }
+}
+
+function shapeResponse(data, options = {}) {
+  if (!data) {
+    return { statusCode: 404, body: JSON.stringify({ error: 'not_found', message: 'Requested season data is unavailable.' }) };
+  }
+
+  const { sportKey, season, category } = options;
+  const availableSeasons = listAvailableSeasons(sportKey);
+  const latestSeason = availableSeasons.length ? availableSeasons[availableSeasons.length - 1] : null;
+  const selectedSeason = season && availableSeasons.includes(Number(season)) ? Number(season) : latestSeason;
+
+  let payload = data;
+  if (category) {
+    const section = data[category];
+    if (typeof section === 'undefined') {
+      return {
+        statusCode: 404,
+        body: JSON.stringify({
+          error: 'invalid_category',
+          message: `Category "${category}" is not available for ${sportKey}.`,
+          availableCategories: Object.keys(data)
+        })
+      };
+    }
+    payload = section;
+  }
+
+  const response = {
+    sport: sportKey,
+    season: selectedSeason,
+    availableSeasons,
+    dataStatus: data?.meta?.dataStatus || 'unknown',
+    lastUpdated: data?.meta?.lastUpdated || null,
+    requestedCategory: category || null,
+    data: payload,
+    metadata: {
+      summaryAvailable: Boolean(data.summary),
+      scheduleAvailable: Array.isArray(data.schedule),
+      keyPlayersAvailable: Boolean(data.keyPlayers),
+      updatePlanIncluded: Boolean(data.updatePlan)
+    }
+  };
+
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(response)
+  };
+}
+
+exports.handler = async (event) => {
+  const params = event.queryStringParameters || {};
+  const sportKey = (params.sport || 'football').toLowerCase();
+
+  if (!SPORT_INDEX[sportKey]) {
+    return {
+      statusCode: 400,
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        error: 'invalid_sport',
+        message: 'Supported sports are football and baseball.',
+        supportedSports: Object.keys(SPORT_INDEX)
+      })
+    };
+  }
+
+  const seasonParam = params.season ? Number(params.season) : null;
+  const category = params.category ? params.category.trim() : null;
+
+  const data = loadSeasonData(sportKey, seasonParam ? String(seasonParam) : null);
+  if (!data) {
+    return {
+      statusCode: 404,
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        error: 'not_found',
+        message: 'Season data not available yet. Check updatePlan for ingestion priorities.'
+      })
+    };
+  }
+
+  return shapeResponse(data, { sportKey, season: seasonParam, category });
+};


### PR DESCRIPTION
## Summary
- add curated 2023 Texas Longhorns football and baseball data bundles for the MCP pipeline
- expose a Netlify function at `/api/longhorns` that serves the season bundles with optional filters and metadata
- document the new endpoint in the API guide so consumers know how to request football schedules or other sections

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cc4806437c8330bd45396433336399