### PR TITLE
feat: integrate espn live scoreboard services

### DIFF
--- a/lib/liveSportsAdapter.js
+++ b/lib/liveSportsAdapter.js
@@ -1,0 +1,265 @@
+import RedisCacheManager from '../services/redis-cache-manager.js';
+import {
+  mapScoreboardGame,
+  normalizeScoreboardParams,
+  normalizeStandings,
+  normalizeStandingsParams,
+} from './liveSportsUtils.js';
+
+const ESPN_SCOREBOARD_BASE_URL = 'https://site.api.espn.com/apis/site/v2/sports';
+const ESPN_STANDINGS_BASE_URL = 'https://site.web.api.espn.com/apis/v2/sports';
+const DEFAULT_TIMEOUT_MS = Number.parseInt(process.env.ESPN_API_TIMEOUT_MS ?? '', 10);
+const SCOREBOARD_TIMEOUT_MS = Number.isFinite(DEFAULT_TIMEOUT_MS) && DEFAULT_TIMEOUT_MS > 0 ? DEFAULT_TIMEOUT_MS : 8000;
+const DEFAULT_USER_AGENT = 'Blaze Intelligence LiveSports/1.0';
+
+const MLB_IDENTIFIERS = { sport: 'baseball', league: 'mlb' };
+const NFL_IDENTIFIERS = { sport: 'football', league: 'nfl' };
+
+const STANDINGS_DEFAULT_TTL = 1800;
+
+class LiveSportsAdapter {
+  constructor(options = {}) {
+    this.cache = new RedisCacheManager({ db: options.redisDb ?? 5, ...(options.redis ?? {}) });
+    this.cacheReady = false;
+    this.timeoutMs = options.timeoutMs ?? SCOREBOARD_TIMEOUT_MS;
+    this.scoreboardTtl = options.scoreboardTtl ?? this.cache.default_ttl?.scoreboard ?? 15;
+    this.standingsTtl = options.standingsTtl ?? this.cache.default_ttl?.standings ?? STANDINGS_DEFAULT_TTL;
+    this.userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
+    this.initialized = false;
+  }
+
+  async initialize() {
+    if (this.initialized) {
+      return;
+    }
+    await this.ensureCache();
+    this.initialized = true;
+    this.warmScoreboards().catch((error) => {
+      console.warn('⚠️  Unable to warm scoreboard cache:', error.message);
+    });
+  }
+
+  async ensureCache() {
+    if (this.cacheReady) {
+      return;
+    }
+    await this.cache.connect();
+    this.cacheReady = true;
+  }
+
+  async warmScoreboards() {
+    await Promise.allSettled([
+      this.getMLBScoreboard(),
+      this.getNFLScoreboard(),
+    ]);
+  }
+
+  buildScoreboardUrl({ sport, league }, params = {}) {
+    const url = new URL(`${ESPN_SCOREBOARD_BASE_URL}/${sport}/${league}/scoreboard`);
+    for (const [key, value] of Object.entries(params)) {
+      if (value != null) {
+        url.searchParams.set(key, value);
+      }
+    }
+    return url.toString();
+  }
+
+  buildStandingsUrl({ sport, league }, params = {}) {
+    const url = new URL(`${ESPN_STANDINGS_BASE_URL}/${sport}/${league}/standings`);
+    for (const [key, value] of Object.entries(params)) {
+      if (value != null) {
+        url.searchParams.set(key, value);
+      }
+    }
+    return url.toString();
+  }
+
+  async fetchJson(url) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': this.userAgent,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`ESPN API request failed (${response.status})`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        throw new Error(`ESPN API request timed out after ${this.timeoutMs}ms`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async fetchScoreboard(identifiers, params = {}) {
+    await this.ensureCache();
+    const normalizedParams = normalizeScoreboardParams(params);
+    const cacheKey = `${identifiers.sport}:${identifiers.league}`;
+
+    const cached = await this.cache.get('scoreboard', cacheKey, normalizedParams);
+    if (cached) {
+      return cached;
+    }
+
+    const url = this.buildScoreboardUrl(identifiers, normalizedParams);
+    const payload = await this.fetchJson(url);
+    const events = Array.isArray(payload?.events) ? payload.events : [];
+    const normalizedEvents = events
+      .map((event) => mapScoreboardGame(identifiers.league, event))
+      .filter((event) => event !== null);
+
+    const scoreboard = {
+      league: identifiers.league.toUpperCase(),
+      fetched_at: new Date().toISOString(),
+      day: payload?.day?.date ?? null,
+      events: normalizedEvents,
+    };
+
+    await this.cache.set('scoreboard', cacheKey, scoreboard, this.scoreboardTtl, normalizedParams);
+    return scoreboard;
+  }
+
+  async fetchStandings(identifiers, params = {}) {
+    await this.ensureCache();
+    const normalizedParams = normalizeStandingsParams(params);
+    const cacheKey = `${identifiers.sport}:${identifiers.league}:standings`;
+
+    const cached = await this.cache.get('standings', cacheKey, normalizedParams);
+    if (cached) {
+      return cached;
+    }
+
+    const url = this.buildStandingsUrl(identifiers, normalizedParams);
+    const payload = await this.fetchJson(url);
+    const standings = normalizeStandings(identifiers.league, payload);
+
+    await this.cache.set('standings', cacheKey, standings, this.standingsTtl, normalizedParams);
+    return standings;
+  }
+
+  async getMLBScoreboard(date) {
+    const params = date ? { dates: date } : {};
+    return this.fetchScoreboard(MLB_IDENTIFIERS, params);
+  }
+
+  async getNFLScoreboard(week) {
+    const params = week ? { week } : {};
+    return this.fetchScoreboard(NFL_IDENTIFIERS, params);
+  }
+
+  async getMLBGameCount(date) {
+    const scoreboard = await this.getMLBScoreboard(date);
+    return scoreboard.events.length;
+  }
+
+  async getNFLGameCount(week) {
+    const scoreboard = await this.getNFLScoreboard(week);
+    return scoreboard.events.length;
+  }
+
+  async getMLBLiveScore(id, date) {
+    const scoreboard = await this.getMLBScoreboard(date);
+    const game = scoreboard.events.find((event) => event.id === String(id));
+    if (!game) {
+      throw new Error(`MLB game ${id} not found`);
+    }
+
+    const mlb = game.mlb ?? {};
+    return {
+      away_team: game.away?.name ?? null,
+      away_team_id: game.away?.id ?? null,
+      away_score: game.away?.score ?? null,
+      home_team: game.home?.name ?? null,
+      home_team_id: game.home?.id ?? null,
+      home_score: game.home?.score ?? null,
+      inning: mlb.inning ?? game.status.shortDetail ?? game.status.detail ?? null,
+      current_state: game.status.detail ?? game.status.shortDetail ?? game.status.state ?? null,
+      first_base: Boolean(mlb.onFirst),
+      second_base: Boolean(mlb.onSecond),
+      third_base: Boolean(mlb.onThird),
+      balls: mlb.balls ?? null,
+      strikes: mlb.strikes ?? null,
+      outs: mlb.outs ?? null,
+      last_play: mlb.lastPlay ?? null,
+      updated_at: scoreboard.fetched_at,
+    };
+  }
+
+  async getNFLLiveScore(id, week) {
+    const scoreboard = await this.getNFLScoreboard(week);
+    const game = scoreboard.events.find((event) => event.id === String(id));
+    if (!game) {
+      throw new Error(`NFL game ${id} not found`);
+    }
+
+    const nfl = game.nfl ?? {};
+    return {
+      away_team: game.away?.name ?? null,
+      away_team_id: game.away?.id ?? null,
+      away_score: game.away?.score ?? null,
+      away_record: game.away?.record ?? null,
+      home_team: game.home?.name ?? null,
+      home_team_id: game.home?.id ?? null,
+      home_score: game.home?.score ?? null,
+      home_record: game.home?.record ?? null,
+      display_game_state: game.status.shortDetail ?? game.status.detail ?? null,
+      game_state: game.status.state ?? null,
+      possession_info: nfl.possession ?? null,
+      clock: nfl.clock ?? null,
+      down_distance_text: nfl.downDistanceText ?? null,
+      last_play: nfl.lastPlay ?? null,
+      updated_at: scoreboard.fetched_at,
+    };
+  }
+
+  async getMLBStandings(options = {}) {
+    return this.fetchStandings(MLB_IDENTIFIERS, options);
+  }
+
+  async getAllLiveScores() {
+    const results = await Promise.allSettled([
+      this.getMLBScoreboard(),
+      this.getNFLScoreboard(),
+    ]);
+
+    const payload = {
+      generated_at: new Date().toISOString(),
+      leagues: [],
+    };
+
+    const [mlbResult, nflResult] = results;
+
+    if (mlbResult.status === 'fulfilled') {
+      payload.leagues.push({ league: 'MLB', events: mlbResult.value.events });
+    } else {
+      payload.leagues.push({ league: 'MLB', error: 'unavailable' });
+    }
+
+    if (nflResult.status === 'fulfilled') {
+      payload.leagues.push({ league: 'NFL', events: nflResult.value.events });
+    } else {
+      payload.leagues.push({ league: 'NFL', error: 'unavailable' });
+    }
+
+    return payload;
+  }
+}
+
+export default LiveSportsAdapter;
+export {
+  mapScoreboardGame,
+  normalizeScoreboardParams,
+  normalizeStandings,
+  normalizeStandingsParams,
+} from './liveSportsUtils.js';

--- a/lib/liveSportsUtils.js
+++ b/lib/liveSportsUtils.js
@@ -1,0 +1,305 @@
+const toNullableNumber = (value) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const resolveRecordSummary = (records) => {
+  if (!Array.isArray(records)) {
+    return null;
+  }
+  const preferred = records.find((record) => record.type === 'total');
+  const fallback = preferred ?? records[0];
+  return fallback?.summary ?? null;
+};
+
+const formatInning = (situation, status) => {
+  if (!situation) {
+    return status?.shortDetail ?? status?.detail ?? status?.description ?? null;
+  }
+  const inning = typeof situation.inning === 'number' ? situation.inning : null;
+  const half = typeof situation.inningHalf === 'string' ? situation.inningHalf : null;
+  if (inning == null && !half) {
+    return status?.shortDetail ?? status?.detail ?? status?.description ?? null;
+  }
+  const label = half ? `${half.charAt(0).toUpperCase()}${half.slice(1)} ` : '';
+  const formatted = `${label}${inning ?? ''}`.trim();
+  if (formatted.length > 0) {
+    return formatted;
+  }
+  return status?.shortDetail ?? status?.detail ?? status?.description ?? null;
+};
+
+const extractBroadcasts = (competition) => {
+  if (!Array.isArray(competition?.broadcasts)) {
+    return [];
+  }
+  const seen = new Set();
+  const broadcasts = [];
+  for (const broadcast of competition.broadcasts) {
+    const candidates = Array.isArray(broadcast?.names) ? broadcast.names : [];
+    for (const name of candidates) {
+      if (typeof name === 'string' && name.trim().length > 0 && !seen.has(name)) {
+        seen.add(name);
+        broadcasts.push(name);
+      }
+    }
+  }
+  return broadcasts;
+};
+
+const mapTeam = (competitor) => {
+  if (!competitor?.team) {
+    return null;
+  }
+
+  const score = toNullableNumber(competitor.score);
+  const linescores = Array.isArray(competitor.linescores)
+    ? competitor.linescores.map((line) => toNullableNumber(line?.value ?? line)).filter((value) => value != null)
+    : undefined;
+
+  return {
+    id: competitor.team.id ?? null,
+    name: competitor.team.displayName ?? competitor.team.name ?? null,
+    abbreviation: competitor.team.abbreviation ?? null,
+    location: competitor.team.location ?? null,
+    logo: Array.isArray(competitor.team.logos) && competitor.team.logos[0]?.href ? competitor.team.logos[0].href : null,
+    score,
+    record: resolveRecordSummary(competitor.records) ?? competitor.record ?? null,
+    ranking: competitor.curatedRank?.current ?? null,
+    linescores,
+  };
+};
+
+const createMlbDetails = (competition, status) => {
+  const situation = competition?.situation ?? {};
+  return {
+    inning: formatInning(situation, status),
+    balls: toNullableNumber(situation.balls),
+    strikes: toNullableNumber(situation.strikes),
+    outs: toNullableNumber(situation.outs),
+    onFirst: Boolean(situation.onFirst),
+    onSecond: Boolean(situation.onSecond),
+    onThird: Boolean(situation.onThird),
+    lastPlay: situation.lastPlay?.text ?? null,
+  };
+};
+
+const createNflDetails = (competition, status) => {
+  const situation = competition?.situation ?? {};
+  return {
+    clock: situation.clock ?? competition?.status?.displayClock ?? status?.shortDetail ?? null,
+    possession: situation.possession ?? null,
+    downDistanceText: situation.shortDownDistanceText ?? situation.downDistanceText ?? null,
+    lastPlay: situation.lastPlay?.text ?? null,
+  };
+};
+
+const createBasketballDetails = (competition, status) => {
+  const situation = competition?.situation ?? {};
+  return {
+    clock: situation.clock ?? competition?.status?.displayClock ?? status?.shortDetail ?? null,
+    possession: situation.possession ?? null,
+    lastPlay: situation.lastPlay?.text ?? null,
+  };
+};
+
+const findCompetitor = (competition, homeAway) => {
+  if (!Array.isArray(competition?.competitors)) {
+    return null;
+  }
+  return competition.competitors.find((competitor) => competitor?.homeAway === homeAway) ?? null;
+};
+
+const mapScoreboardGame = (league, event) => {
+  const competition = Array.isArray(event?.competitions) ? event.competitions[0] : null;
+  if (!competition) {
+    return null;
+  }
+
+  const status = competition.status?.type ?? event.status?.type ?? {};
+  const home = findCompetitor(competition, 'home');
+  const away = findCompetitor(competition, 'away');
+
+  const summary = {
+    id: event.id,
+    uid: event.uid ?? null,
+    league: league.toUpperCase(),
+    name: event.name ?? null,
+    shortName: event.shortName ?? null,
+    startTime: competition.date ?? event.date ?? null,
+    venue: competition.venue?.fullName ?? null,
+    status: {
+      state: status.state ?? status.name ?? null,
+      detail: status.detail ?? status.description ?? null,
+      shortDetail: status.shortDetail ?? status.detail ?? status.description ?? null,
+      completed: Boolean(status.completed ?? (status.state === 'post' || status.state === 'final')),
+    },
+    broadcasts: extractBroadcasts(competition),
+    home: mapTeam(home),
+    away: mapTeam(away),
+  };
+
+  if (league === 'mlb') {
+    summary.mlb = createMlbDetails(competition, status);
+  } else if (league === 'nfl') {
+    summary.nfl = createNflDetails(competition, status);
+  } else if (league === 'nba') {
+    summary.nba = createBasketballDetails(competition, status);
+  }
+
+  return summary;
+};
+
+const normalizeScoreboardParams = (params = {}) => {
+  const normalized = {};
+
+  const datesInput = params.dates ?? params.date;
+  if (typeof datesInput === 'string' && datesInput.trim().length > 0) {
+    const clean = datesInput.replace(/-/g, '');
+    if (/^\d{8}$/.test(clean)) {
+      normalized.dates = clean;
+    }
+  } else if (typeof datesInput === 'number' && Number.isFinite(datesInput)) {
+    const padded = datesInput.toString().padStart(8, '0');
+    if (/^\d{8}$/.test(padded)) {
+      normalized.dates = padded;
+    }
+  }
+
+  if (params.week != null) {
+    const week = Number.parseInt(params.week, 10);
+    if (Number.isFinite(week) && week > 0) {
+      normalized.week = week.toString();
+    }
+  }
+
+  if (params.season != null) {
+    const season = Number.parseInt(params.season, 10);
+    if (Number.isFinite(season)) {
+      normalized.season = season.toString();
+    }
+  }
+
+  const seasonTypeInput = params.seasontype ?? params.seasonType;
+  if (seasonTypeInput != null) {
+    const seasonType = Number.parseInt(seasonTypeInput, 10);
+    if (Number.isFinite(seasonType)) {
+      normalized.seasontype = seasonType.toString();
+    }
+  }
+
+  if (params.limit != null) {
+    const limit = Number.parseInt(params.limit, 10);
+    if (Number.isFinite(limit) && limit > 0) {
+      normalized.limit = Math.min(limit, 100).toString();
+    }
+  }
+
+  return normalized;
+};
+
+const normalizeStandingsParams = (params = {}) => {
+  const normalized = {};
+  if (params.season != null) {
+    const season = Number.parseInt(params.season, 10);
+    if (Number.isFinite(season)) {
+      normalized.season = season.toString();
+    }
+  }
+  if (params.group != null) {
+    const group = Number.parseInt(params.group, 10);
+    if (Number.isFinite(group)) {
+      normalized.group = group.toString();
+    }
+  }
+  return normalized;
+};
+
+const normalizeStandings = (league, payload) => {
+  const groups = Array.isArray(payload?.children) ? payload.children : [];
+  const result = [];
+
+  for (const group of groups) {
+    const entries = Array.isArray(group?.standings?.entries) ? group.standings.entries : [];
+    const teams = [];
+    for (const entry of entries) {
+      const stats = Array.isArray(entry?.stats) ? entry.stats : [];
+      const statMap = {};
+      for (const stat of stats) {
+        if (!stat?.name) {
+          continue;
+        }
+        const value = stat.value ?? stat.displayValue ?? stat.description ?? null;
+        switch (stat.name) {
+          case 'gamesPlayed':
+            statMap.gamesPlayed = toNullableNumber(value);
+            break;
+          case 'wins':
+            statMap.wins = toNullableNumber(value);
+            break;
+          case 'losses':
+            statMap.losses = toNullableNumber(value);
+            break;
+          case 'ties':
+            statMap.ties = toNullableNumber(value);
+            break;
+          case 'winPercent':
+            statMap.winPercent = typeof value === 'number' ? value : toNullableNumber(value);
+            break;
+          case 'gamesBack':
+            statMap.gamesBack = typeof value === 'string' ? value : toNullableNumber(value);
+            break;
+          case 'runsFor':
+          case 'pointsFor':
+            statMap.pointsFor = toNullableNumber(value);
+            break;
+          case 'runsAgainst':
+          case 'pointsAgainst':
+            statMap.pointsAgainst = toNullableNumber(value);
+            break;
+          case 'streak':
+            statMap.streak = typeof value === 'string' ? value : null;
+            break;
+          default:
+            break;
+        }
+      }
+
+      teams.push({
+        teamId: entry?.team?.id ?? null,
+        teamName: entry?.team?.displayName ?? entry?.team?.name ?? null,
+        abbreviation: entry?.team?.abbreviation ?? null,
+        record: entry?.stats?.find((stat) => stat.name === 'overallRecord')?.displayValue ?? null,
+        stats: statMap,
+      });
+    }
+
+    result.push({
+      id: group?.id ?? null,
+      name: group?.name ?? null,
+      abbreviation: group?.abbreviation ?? null,
+      teams,
+    });
+  }
+
+  return {
+    league: league.toUpperCase(),
+    season: payload?.season?.year ?? null,
+    fetched_at: new Date().toISOString(),
+    groups: result,
+  };
+};
+
+export {
+  mapScoreboardGame,
+  normalizeScoreboardParams,
+  normalizeStandings,
+  normalizeStandingsParams,
+  toNullableNumber,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "bcryptjs": "^2.4.3",
-        "hono": "^4.9.8"
+        "hono": "^4.9.8",
+        "ioredis": "^5.7.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250918.0"
@@ -23,11 +24,52 @@
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.4.0.tgz",
+      "integrity": "sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==",
+      "license": "MIT"
+    },
     "node_modules/bcryptjs": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/hono": {
       "version": "4.9.8",
@@ -37,6 +79,75 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/ioredis": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.7.0.tgz",
+      "integrity": "sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.3.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
-    "hono": "^4.9.8"
+    "hono": "^4.9.8",
+    "ioredis": "^5.7.0"
   },
   "keywords": [
     "cloudflare",

--- a/server.js
+++ b/server.js
@@ -48,6 +48,9 @@ app.set('trust proxy', 1);
 // Initialize sports data services
 const sportsData = new SportsDataService();
 const liveSportsAdapter = new LiveSportsAdapter();
+liveSportsAdapter.initialize().catch((error) => {
+  console.warn('⚠️  Live sports adapter initialization failed:', error.message);
+});
 const aiAnalytics = new AIAnalyticsService();
 const cardinalsAPI = new CardinalsDataIntegration();
 const digitalCombineBackend = new DigitalCombineBackend(pool);
@@ -738,6 +741,17 @@ app.get('/api/live-sports/mlb/scoreboard', async (req, res) => {
   } catch (error) {
     console.error('MLB scoreboard error:', error);
     res.status(500).json({ error: 'Failed to fetch MLB scoreboard' });
+  }
+});
+
+app.get('/api/live-sports/mlb/standings', async (req, res) => {
+  try {
+    const { season, group } = req.query;
+    const data = await liveSportsAdapter.getMLBStandings({ season, group });
+    res.json(data);
+  } catch (error) {
+    console.error('MLB standings error:', error);
+    res.status(500).json({ error: 'Failed to fetch MLB standings' });
   }
 });
 

--- a/services/redis-cache-manager.js
+++ b/services/redis-cache-manager.js
@@ -33,7 +33,14 @@ class RedisCacheManager {
       analytics: 'analytics:',
       session: 'session:',
       rate_limit: 'rate:',
-      temp: 'temp:'
+      temp: 'temp:',
+      scoreboard: 'scoreboard:',
+      standings: 'standings:'
+    };
+
+    const parseTtl = (value, fallback) => {
+      const numeric = Number.parseInt(value ?? '', 10);
+      return Number.isFinite(numeric) && numeric > 0 ? numeric : fallback;
     };
 
     this.default_ttl = {
@@ -42,7 +49,9 @@ class RedisCacheManager {
       analytics: 3600, // 1 hour
       session: 86400, // 24 hours
       rate_limit: 900, // 15 minutes
-      temp: 60 // 1 minute
+      temp: 60, // 1 minute
+      scoreboard: parseTtl(process.env.SCOREBOARD_CACHE_TTL, 15),
+      standings: parseTtl(process.env.STANDINGS_CACHE_TTL, 1800)
     };
   }
 

--- a/tests/liveSportsAdapter.test.mjs
+++ b/tests/liveSportsAdapter.test.mjs
@@ -1,0 +1,166 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  mapScoreboardGame,
+  normalizeScoreboardParams,
+  normalizeStandings,
+} from '../lib/liveSportsUtils.js';
+
+test('normalizeScoreboardParams sanitizes date input', () => {
+  const params = normalizeScoreboardParams({ date: '2025-07-04', week: '3', season: '2025', seasontype: '2', limit: '150' });
+  assert.deepEqual(params, {
+    dates: '20250704',
+    week: '3',
+    season: '2025',
+    seasontype: '2',
+    limit: '100',
+  });
+});
+
+test('mapScoreboardGame transforms MLB event', () => {
+  const event = {
+    id: '401',
+    uid: 's:1~l:10~e:401',
+    name: 'Aces at Bats',
+    shortName: 'ACE@BAT',
+    date: '2025-08-12T18:05Z',
+    competitions: [
+      {
+        id: '401-1',
+        date: '2025-08-12T18:05Z',
+        status: { type: { state: 'in', detail: 'Bottom 5th', shortDetail: 'Bot 5th' } },
+        venue: { fullName: 'Blaze Ballpark' },
+        broadcasts: [{ names: ['BI Network'] }],
+        competitors: [
+          {
+            homeAway: 'home',
+            score: '3',
+            curatedRank: { current: 7 },
+            records: [{ type: 'total', summary: '60-45' }],
+            team: {
+              id: '2',
+              displayName: 'Blaze Bats',
+              abbreviation: 'BAT',
+              location: 'Blaze City',
+              logos: [{ href: 'https://example.com/bats.png' }],
+            },
+            linescores: [{ value: 0 }, { value: 2 }, { value: 1 }, { value: 0 }, { value: 0 }],
+          },
+          {
+            homeAway: 'away',
+            score: '1',
+            records: [{ type: 'total', summary: '55-50' }],
+            team: {
+              id: '1',
+              displayName: 'Austin Aces',
+              abbreviation: 'ACE',
+              logos: [{ href: 'https://example.com/aces.png' }],
+            },
+          },
+        ],
+        situation: {
+          inning: 5,
+          inningHalf: 'bottom',
+          balls: 2,
+          strikes: 1,
+          outs: 1,
+          onFirst: true,
+          onSecond: false,
+          onThird: true,
+          lastPlay: { text: 'Line drive single to left.' },
+        },
+      },
+    ],
+  };
+
+  const game = mapScoreboardGame('mlb', event);
+  assert.equal(game.id, '401');
+  assert.equal(game.league, 'MLB');
+  assert.equal(game.home.name, 'Blaze Bats');
+  assert.equal(game.away.score, 1);
+  assert.equal(game.status.shortDetail, 'Bot 5th');
+  assert.ok(game.mlb);
+  assert.equal(game.mlb.inning, 'Bottom 5');
+  assert.equal(game.mlb.onFirst, true);
+  assert.equal(game.broadcasts[0], 'BI Network');
+});
+
+test('mapScoreboardGame transforms NFL event', () => {
+  const event = {
+    id: '301',
+    name: 'Legends vs Titans',
+    shortName: 'LEG@TIT',
+    date: '2025-09-15T17:00Z',
+    competitions: [
+      {
+        id: '301-1',
+        date: '2025-09-15T17:00Z',
+        status: { type: { state: 'in', detail: 'Q3 08:35', shortDetail: 'Q3 8:35' } },
+        competitors: [
+          {
+            homeAway: 'home',
+            score: '14',
+            records: [{ type: 'total', summary: '1-0' }],
+            team: { id: '33', displayName: 'Nashville Titans', abbreviation: 'TIT' },
+          },
+          {
+            homeAway: 'away',
+            score: '10',
+            records: [{ type: 'total', summary: '0-1' }],
+            team: { id: '44', displayName: 'Legends FC', abbreviation: 'LEG' },
+          },
+        ],
+        situation: {
+          clock: '08:35',
+          possession: '33',
+          shortDownDistanceText: '3rd & 2',
+          lastPlay: { text: 'Run up the middle for 3 yards' },
+        },
+      },
+    ],
+  };
+
+  const game = mapScoreboardGame('nfl', event);
+  assert.equal(game.nfl.clock, '08:35');
+  assert.equal(game.nfl.downDistanceText, '3rd & 2');
+  assert.equal(game.home.record, '1-0');
+  assert.equal(game.away.name, 'Legends FC');
+  assert.equal(game.status.state, 'in');
+});
+
+test('normalizeStandings flattens ESPN payload', () => {
+  const payload = {
+    season: { year: 2025 },
+    children: [
+      {
+        id: '1',
+        name: 'American League',
+        abbreviation: 'AL',
+        standings: {
+          entries: [
+            {
+              team: { id: '2', displayName: 'Blaze Bats', abbreviation: 'BAT' },
+              stats: [
+                { name: 'gamesPlayed', value: 162 },
+                { name: 'wins', value: 100 },
+                { name: 'losses', value: 62 },
+                { name: 'winPercent', value: 0.617 },
+                { name: 'streak', displayValue: 'W2' },
+                { name: 'pointsFor', value: 820 },
+                { name: 'pointsAgainst', value: 650 },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const standings = normalizeStandings('mlb', payload);
+  assert.equal(standings.league, 'MLB');
+  assert.equal(standings.season, 2025);
+  assert.equal(standings.groups.length, 1);
+  assert.equal(standings.groups[0].teams[0].stats.wins, 100);
+  assert.equal(standings.groups[0].teams[0].stats.pointsAgainst, 650);
+});


### PR DESCRIPTION
## Summary
- add a reusable LiveSportsAdapter backed by Redis that fetches ESPN scoreboards and MLB standings with automatic caching
- expose the adapter through existing Express endpoints, including a new MLB standings route and warmup on startup
- factor shared parsing logic into utilities with unit tests and extend the Redis cache manager plus dependencies for scoreboard data

## Testing
- node --test tests/liveSportsAdapter.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cdf123ae1c8330b94d5b29e109670d